### PR TITLE
Prepdb super fix - prepareClassDB now requires superuser privileges

### DIFF
--- a/src/prepareClassDB.sql
+++ b/src/prepareClassDB.sql
@@ -554,11 +554,9 @@ $$ LANGUAGE sql
    SECURITY DEFINER;
 
 --Set execution permissions
---Currently, we are keeping listUserConnections() owned by the creating user.
+--The function remains owned by the creating user (a "superuser"):
 -- This allows instructors and db managers unrestricted access to pg_stat_activity
--- if the creating user is a superuser.
 --Otherwise, they cannot see info like ip address and timestamps of other users
---In all cases, listUserConnections will be able to list PIDs from all users
 REVOKE ALL ON FUNCTION
    classdb.listUserConnections(VARCHAR(63))
    FROM PUBLIC;


### PR DESCRIPTION
This PR results in prepareClassDB requiring that the user running the script be a "superuser". This is required with the current setup of ClassDB because the `public` schema is owned by the `postgres` (default superuser) account, not the owner of the database the schema is in. Related Issue: #39.

Requiring that the current user is a superuser also eliminates the need to check that the current user is the owner of the database. Related Issue: #38

Finally, it also eliminates the fact that listUserconnections could have differing amounts of information available depending on the privileges of the user who ran the script. Related Issue: #30

The documentation for ClassDB will have to be updated to reflect the new privileges requirements, and that last point.