### PR TITLE
Removed permissions on create/dropUser from Instructor and DBManager

### DIFF
--- a/src/addUserMgmt.sql
+++ b/src/addUserMgmt.sql
@@ -372,40 +372,6 @@ GRANT EXECUTE ON FUNCTION classdb.dropDBManager(userName VARCHAR(63))
    TO ClassDB_Instructor, ClassDB_DBManager;
 
 
-DROP FUNCTION IF EXISTS classdb.dropUser(userName VARCHAR(63));
---The following procedure drops a user regardless of their role memberships.
--- This will also drop the user's schema and the objects contained within, if
--- the schema exists. Currently, it also drops the value from the Student table
--- if the user was a member of the Student role, and from the Instructor table if
--- they were an instructor.
-CREATE FUNCTION classdb.dropUser(userName VARCHAR(63)) RETURNS VOID AS
-$$
-BEGIN
-   IF classdb.isRoleDefined($1)
-      THEN
-      IF pg_catalog.pg_has_role(classdb.foldPgID($1), 'classdb_student', 'member')
-         THEN
-         DELETE FROM classdb.Student WHERE userName = classdb.foldPgID($1);
-      END IF;
-
-      IF pg_catalog.pg_has_role(classdb.foldPgID($1), 'classdb_instructor', 'member')
-         THEN
-         DELETE FROM classdb.Instructor WHERE userName = classdb.foldPgID($1);
-      END IF;
-
-      EXECUTE format('DROP SCHEMA %s CASCADE', $1);
-      EXECUTE format('DROP ROLE %s', $1);
-   ELSE
-      RAISE NOTICE 'User "%" is not a registered user', $1;
-   END IF;
-END;
-$$ LANGUAGE plpgsql
-   SECURITY DEFINER;
-
---Change function ownership and set execution permissions
-ALTER FUNCTION classdb.dropUser(userName VARCHAR(63)) OWNER TO ClassDB;
-REVOKE ALL ON FUNCTION classdb.dropUser(userName VARCHAR(63)) FROM PUBLIC;
-
 
 --Define a function to reset a user's password to a default value
 -- default password is the username: it is not necessarily the same as the


### PR DESCRIPTION
Removed execute permissions on `classdb.createUser()` and `classdb.dropUser()` from Instructor and DBManager. 
Fixes #113