### PR TITLE
Customize home pg for site & wiki

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -8,12 +8,12 @@ ClassDB was developed at the Data Science & Systems Lab ([DASSL](http://sites.wc
 
 ## Documentation
 
-The documentation for the [latest release](https://github.com/DASSL/ClassDB/releases/latest) is on the [ClassDB web site](https://dassl.github.io/ClassDB/):
-* [Table of contents](https://dassl.github.io/ClassDB/Table-of-Contents)
-* [Quick Start](https://dassl.github.io/ClassDB/Introduction#quick-start)
-* [Credits](https://dassl.github.io/ClassDB/Credits)
+The documentation for the version of ClassDB in development is on this Wiki:
+* [Table of contents](Table-of-Contents)
+* [Quick Start](Introduction#quick-start)
+* [Credits](Credits)
 
-The documentation for the version in development is on the [ClassDB Wiki](https://github.com/DASSL/ClassDB/wiki).
+The documentation for the [latest release](https://github.com/DASSL/ClassDB/releases/latest) is on the [ClassDB web site](https://dassl.github.io/ClassDB/).
 
 ## Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,10 @@ ClassDB was developed at the Data Science & Systems Lab ([DASSL](http://sites.wc
 
 ## Documentation
 
-The documentation for the [latest release](https://github.com/DASSL/ClassDB/releases/latest) is on the [ClassDB web site](https://dassl.github.io/ClassDB/):
-* [Table of contents](https://dassl.github.io/ClassDB/Table-of-Contents)
-* [Quick Start](https://dassl.github.io/ClassDB/Introduction#quick-start)
-* [Credits](https://dassl.github.io/ClassDB/Credits)
+The documentation for the [latest release](https://github.com/DASSL/ClassDB/releases/latest) of ClassDB is on this site:
+* [Table of contents](Table-of-Contents)
+* [Quick Start](Introduction#quick-start)
+* [Credits](Credits)
 
 The documentation for the version in development is on the [ClassDB Wiki](https://github.com/DASSL/ClassDB/wiki).
 


### PR DESCRIPTION
Sorry about having to make this change, but I think it is required in order to make sure we are not lost when editing/browsing the wiki:

Edited language in `docs/index.md` and `docs/home.md` so it is less disorienting when reading the site and the wiki.

This change also reduces the number of absolute URLs used in each version of the home page.

I have already configured the repo to publish the `docs` folder to the web site.