### PR TITLE
Readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://postgresql.org"><img src="https://img.shields.io/badge/Powered%20by-PostgreSQL-blue.svg"/></a>
-<a href="https://github.com"><img src="https://img.shields.io/badge/Hosted%20by-GitHub-brightgreen.svg"/></a>
+<a href="https://github.com"><img src="https://img.shields.io/badge/Hosted%20on-GitHub-brightgreen.svg"/></a>
 <a href="https://zenhub.com"><img src="https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png"/></a>
 <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img src="https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg"/></a>
 


### PR DESCRIPTION
I have added badges for GitHub, Zenhub, Postgres, and CC.

The text on the GitHub badge is custom, and can easily be changed by modifying the URL of the image. "Project hosting and management by" might be a bit too wordy.

I wonder if there should be another header before the sentence introducing the badges, since it doesn't perfectly fit the "Contributing" section. That sentence before the badges was borrowed from the Credits page on the Wiki/Website, but made in present tense ("is aided" rather than "was aided").

The creative commons badge is near the bottom of the page, under the licensing information.