### PR TITLE
Add test Banner roster

### DIFF
--- a/tests/importStudents/README.md
+++ b/tests/importStudents/README.md
@@ -1,4 +1,4 @@
-testBannerRosterREADME.md - ClassDB
+README.md - ClassDB
 
 Sean Murthy   
 Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)

--- a/tests/importStudents/testBannerRoster.csv
+++ b/tests/importStudents/testBannerRoster.csv
@@ -1,0 +1,19 @@
+Last Name,First Name,Middle Name,ID,Reg Status,Level,Degree,Program,Major,Class,Credits,WCSU Email
+Smith,Jacob,James,83816763,**Web Registered**,Undergraduate,Bachelor of Arts,BA Computer Science,Computer Science,Sophomore,4,Smith.Jacob@example.edu
+Johnson,Michael,,40235948,**Web Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Junior,4,Johnson.Michael@example.edu
+Williams,Madison,Jerry,66145330,**Web Registered**,Undergraduate,Bachelor of Arts,BA Computer Science,Computer Science,Sophomore,4,Williams.Madison@example.edu
+Brown,Joshua,,24615379,**Web Registered**,Undergraduate,Bachelor of Science * ,BS Computer Science * ,Computer Science * ,Senior,4,Brown.Joshua@example.edu
+Jones,Sarah,Mathew,32780676,**Registered**,Undergraduate,Bachelor of Arts,BA Math,Mathematics,Senior,4,Jones.Sarah@example.edu
+Garcia,Nicholas,,88004991,**Web Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Junior,4,Garcia.Nicholas@example.edu
+Miller,Andrew,G,15986082,**Web Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Senior,4,Miller.Andrew@example.edu
+Davis,Joseph,,89440822,**Web Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Sophomore,4,Davis.Joseph@example.edu
+Rodriguez,Elizabeth,O,80028901,**Web Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Junior,4,Rodriguez.Elizabeth@example.edu
+Martinez,Tyler,,86748573,**Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Freshman,4,Martinez.Tyler@example.edu
+Hernandez,William,Vinny,64404005,**Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Junior,4,Hernandez.William@example.edu
+Lopez,Alyssa,V,46137687,**Web Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Junior,4,Lopez.Alyssa@example.edu
+Gonzalez,Kayla,,36731378,**Web Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Junior,4,Gonzalez.Kayla@example.edu
+Wilson,John,Jonathan,29681784,**Web Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Senior,4,Wilson.John@example.edu
+Anderson,Brianna,Kevin,27506595,**Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Freshman,4,Anderson.Brianna@example.edu
+Thomas,David,,50004300,**Web Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Senior,4,Thomas.David@example.edu
+Taylor,Emma,B,44989904,**Web Registered**,Undergraduate,Bachelor of Science,BS Computer Science,Computer Science,Junior,4,Taylor.Emma@example.edu
+Moore,James,,31068358,**Web Registered**,Undergraduate,Bachelor of Arts,BA Music,Music,Junior,4,Moore.James@example.edu

--- a/tests/importStudents/testBannerRoster.md
+++ b/tests/importStudents/testBannerRoster.md
@@ -1,0 +1,20 @@
+testBannerRosterREADME.md - ClassDB
+
+Sean Murthy   
+Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+
+(C) 2017- DASSL. ALL RIGHTS RESERVED.   
+Licensed to others under CC 4.0 BY-SA-NC:   
+https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+---
+
+The file `testBannerRoster.csv` ("test file") is a sample CSV-formatted file containing a roster the way the [Elucian Banner](http://www.ellucian.com/student-information-system/) system generates at WCSU.
+
+The column names, number, data types, and data sizes ("the structure") in the test file are representative of a roster at WCSU.
+
+The data in the test file is not an actual roster. The content of every cell is fabricated to match the structure the Banner system generates at WCSU.
+
+It is possible the structure of a roster at another university (even if they use the Banner system) is quite different. Specifically, anticipate that column name, number of columns, column order, and data size to be different. For example, the column name `WCSU EMail` is virtually guaranteed to be different at another university.


### PR DESCRIPTION
The commits in this PR add a sample Banner CSV roster to facilitate testing of the eventual resolution to Issue #51 (add student users in bulk). A README file is also added.

The sample roster is added to the `tests` folder so it can become part of unit testing the code to add student users in bulk.