### PR TITLE
Initial version of addUserMgmt.sql

### DIFF
--- a/src/addRoleBaseMgmt.sql
+++ b/src/addRoleBaseMgmt.sql
@@ -318,25 +318,25 @@ CREATE OR REPLACE FUNCTION
 $$
 BEGIN
 
-   --test if a ClassDB role name is supplied
+   --revoke only a ClassDB role
    -- raise an exception (not a notice) because the role name must be correct
    IF NOT ClassDB.isClassDBRoleName($2) THEN
       RAISE EXCEPTION 'Invalid argument: role name "%" not expected', $2;
    END IF;
 
-   --test if server has a role with the given name
+   --should be a server role
    IF NOT ClassDB.isServerRoleDefined($1) THEN
       RAISE NOTICE 'User "%" is not defined in the server', $1;
       RETURN;
    END IF;
 
-   --test if user is known
+   --should be a known user
    IF NOT ClassDB.isUser($1) THEN
       RAISE NOTICE 'User "%" is not known', $1;
       RETURN;
    END IF;
 
-   --test if user is a member of the specified role
+   --user should already have the role to revoke
    IF NOT ClassDB.isMember($1, $2) THEN
       RAISE NOTICE 'User "%" is not a member of role "%"', $1, $2;
       RETURN;
@@ -345,8 +345,7 @@ BEGIN
    --revoke the specified ClassDB role from the user
    EXECUTE FORMAT('REVOKE %s FROM %s', $2, $1);
 
-   --test if user continues to be a member of other ClassDB roles
-   -- only for informational purpose
+   --inform if user continues to be a member of other ClassDB roles
    IF ClassDB.hasClassDBRole($1) THEN
       RAISE NOTICE
          'User "%" remains a member of one or more additional ClassDB roles', $1;
@@ -356,7 +355,6 @@ END;
 $$ LANGUAGE plpgsql
    SECURITY DEFINER;
 
---Change function ownership and set execution permissions
 ALTER FUNCTION
    ClassDB.revokeClassDBRole(ClassDB.IDNameDomain, ClassDB.IDNameDomain)
    OWNER TO ClassDB;

--- a/src/addRoleBaseMgmt.sql
+++ b/src/addRoleBaseMgmt.sql
@@ -273,7 +273,9 @@ BEGIN
    --  for ON CONFLICT ON CONSTRAINT: see the last-but-one example at
    --  https://www.postgresql.org/docs/9.6/static/sql-insert.html
    IF ClassDB.isRoleKnown($1) THEN
-      UPDATE ClassDB.RoleBase SET FullName = $2, ExtraInfo = $5;
+      UPDATE ClassDB.RoleBase R
+      SET FullName = $2, ExtraInfo = $5
+      WHERE R.RoleName = ClassDB.foldPgID($1);
    ELSE
       INSERT INTO ClassDB.RoleBase
       VALUES(ClassDB.foldPgID($1), $2, $3, ClassDB.foldPgID($4), $5);

--- a/src/addUserMgmt.sql
+++ b/src/addUserMgmt.sql
@@ -182,7 +182,7 @@ BEGIN
       CREATE TRIGGER RejectConnectionActivityUpdate
       BEFORE UPDATE ON ClassDB.ConnectionActivity
       EXECUTE PROCEDURE
-         ClassDB.declineUpdate('UPDATE', 'ClassDB.ConnectionActivity');
+         ClassDB.rejectOperation('UPDATE', 'ClassDB.ConnectionActivity');
    END IF;
 
 END

--- a/src/addUserMgmt.sql
+++ b/src/addUserMgmt.sql
@@ -1,0 +1,200 @@
+--addUserMgmt.sql - ClassDB
+
+--Sean Murthy
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
+
+--(C) 2017- DASSL. ALL RIGHTS RESERVED.
+--Licensed to others under CC 4.0 BY-SA-NC
+--https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+--PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+
+--This script requires the current user to be a superuser
+
+--This script should be run after addRoleBaseMgmt.sql
+
+--This script creates the tables,views, and triggers specific to user management
+-- (not for team management)
+
+START TRANSACTION;
+
+--Suppress NOTICE messages for this script: won't apply to functions created here
+-- hides unimportant but possibly confusing msgs generated as the script executes
+SET LOCAL client_min_messages TO WARNING;
+
+
+--Make sure the current user has sufficient privilege to run this script
+-- privileges required: superuser
+DO
+$$
+BEGIN
+   IF NOT ClassDB.isSuperUser() THEN
+      RAISE EXCEPTION 'Insufficient privileges: script must be run as a user'
+                      ' with superuser privileges';
+   END IF;
+END
+$$;
+
+
+
+--Define a table to record DDL activity of users
+-- no primary key is defined because there are no viable key attributes, and
+-- there is no benefit to having a primary key
+-- UserName is not constrained to known users because DDL activity may be
+-- maintained for users who are no longer known, but see trigger definitions
+-- DDLOperation and DDLObject are unsized so they can contain arbitrary strings
+CREATE TABLE IF NOT EXISTS ClassDB.DDLActivity
+(
+  UserName ClassDB.IDNameDomain NOT NULL, --session user performing the operation
+  StatementStartedAtUTC TIMESTAMP NOT NULL, --time at which the DDL op began
+  DDLOperation VARCHAR NOT NULL --the actual DDL op, e.g., "DROP TABLE"
+   CHECK(TRIM(DDLOperation) <> ''),
+  DDLObject VARCHAR NOT NULL --name of the object of the DDL operation
+   CHECK(TRIM(DDLObject) <> '')
+);
+
+--Set table permissions
+-- make ClassDB the owner so it can perform any operation on it
+-- prevent everyone else from doing anything with the table, except permit
+-- instructors and DB managers to read rows
+-- this pattern of ownership and grant/revoke applies to all objects defined in
+-- this script: for brevity, such code is not prefaced ain with comments unless
+-- the code does something significantly different
+ALTER TABLE ClassDB.DDLActivity OWNER TO ClassDB;
+REVOKE ALL PRIVILEGES ON ClassDB.DDLActivity FROM PUBLIC;
+GRANT SELECT ON ClassDB.DDLActivity TO ClassDB_Instructor, ClassDB_DBManager;
+
+
+
+--Define a table to record connection activity of users
+-- no primary key is defined because there are no viable key attributes, and
+-- there is no benefit to having a primary key
+-- UserName is not constrained to known users because DDL activity may be
+-- maintained for users who are no longer known, but see trigger definitions
+CREATE TABLE IF NOT EXISTS ClassDB.ConnectionActivity
+(
+  UserName ClassDB.IDNameDomain NOT NULL, --session user creating the connection
+  AcceptedAtUTC TIMESTAMP NOT NULL --time at which the server accepted connection
+);
+
+ALTER TABLE ClassDB.ConnectionActivity OWNER TO ClassDB;
+REVOKE ALL PRIVILEGES ON ClassDB.ConnectionActivity FROM PUBLIC;
+GRANT SELECT ON ClassDB.ConnectionActivity TO ClassDB_Instructor, ClassDB_DBManager;
+
+
+
+--Define a trigger function to raise an exception that an operation is disallowed
+-- used to prevent non-user inserts to, and any updates to, tables DDLActivity
+-- and ConnectionActivity
+-- trigger functions cannot accept paramers, but the 0-based array TG_ARGV will
+-- contain the arguments specified in the corresponding trigger definition
+-- OK to address non-existent entries in TG_ARGV: just returns NULL
+-- be careful editing this function: it is highly customized for ClassDB's needs
+CREATE OR REPLACE FUNCTION ClassDB.rejectOperation()
+RETURNS TRIGGER AS
+$$
+BEGIN
+   IF TG_ARGV[0] = 'INSERT' THEN
+      RAISE EXCEPTION
+         'Constraint violation: value of column %.UserName is not a known user',
+         TG_ARGV[1];
+   ELSIF TG_ARGV[0] = 'UPDATE' THEN
+      RAISE EXCEPTION
+         'Invalid operation: UPDATE operation is not permitted on table "%"',
+         TG_ARGV[1];
+   ELSE
+      RAISE EXCEPTION 'Invalid use of trigger function';
+   END IF;
+END;
+$$ LANGUAGE plpgsql
+   SECURITY DEFINER;
+
+ALTER FUNCTION
+   ClassDB.revokeClassDBRole(ClassDB.IDNameDomain, ClassDB.IDNameDomain)
+   OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION
+   ClassDB.revokeClassDBRole(ClassDB.IDNameDomain, ClassDB.IDNameDomain)
+   FROM PUBLIC;
+
+
+--Define a temporary function to determine if a trigger is defined
+-- move the function to the ClassDB schema (and probably to addHelpers.sql) if
+-- it is useful in other scripts
+CREATE OR REPLACE FUNCTION
+   pg_temp.isTriggerDefined(schemaName ClassDB.IDNameDomain,
+                            triggerName ClassDB.IDNameDomain
+                           )
+   RETURNS BOOLEAN AS
+$$
+   SELECT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TRIGGERS
+                  WHERE trigger_schema = ClassDB.foldPgID($1)
+                        AND trigger_name = ClassDB.foldPgID($2)
+                 );
+$$ LANGUAGE sql
+   STABLE
+   RETURNS NULL ON NULL INPUT;
+
+
+
+--Define triggers to prevent non-user INSERT, and any UPDATE, to tables DDLActivity
+-- and ConnectionActivity
+-- must check catalog to see if triggers are defined because CREATE TRIGGER
+-- does not have the IF NOT EXISTS option
+DO
+$$
+BEGIN
+
+   --reject non-user insert into DDLActivity
+   IF NOT pg_temp.isTriggerDefined('classdb', 'RejectNonUserDDLActivityInsert')
+   THEN
+      CREATE TRIGGER RejectNonUserDDLActivityInsert
+      BEFORE INSERT ON ClassDB.DDLActivity
+      FOR EACH ROW
+      WHEN (NOT ClassDB.isUser(NEW.UserName))
+      EXECUTE PROCEDURE ClassDB.rejectOperation('INSERT', 'ClassDB.DDLActivity');
+   END IF;
+
+   --reject non-user insert into DDLActivity
+   IF NOT
+      pg_temp.isTriggerDefined('classdb', 'RejectNonUserConnectionActivityInsert')
+   THEN
+      CREATE TRIGGER RejectNonUserConnectionActivityInsert
+      BEFORE INSERT ON ClassDB.ConnectionActivity
+      FOR EACH ROW
+      WHEN (NOT ClassDB.isUser(NEW.UserName))
+      EXECUTE PROCEDURE
+         ClassDB.rejectOperation('INSERT', 'ClassDB.ConnectionActivity');
+   END IF;
+
+   --reject all updates to DDLActivity
+   IF NOT pg_temp.isTriggerDefined('classdb', 'RejectDDLActivityUpdate') THEN
+      CREATE TRIGGER RejectDDLActivityUpdate
+      BEFORE UPDATE ON ClassDB.DDLActivity
+      EXECUTE PROCEDURE ClassDB.rejectOperation('UPDATE', 'ClassDB.DDLActivity');
+   END IF;
+
+   --reject all updates to ConnectionActivity
+   IF NOT pg_temp.isTriggerDefined('classdb', 'RejectConnectionActivityUpdate')
+   THEN
+      CREATE TRIGGER RejectConnectionActivityUpdate
+      BEFORE UPDATE ON ClassDB.ConnectionActivity
+      EXECUTE PROCEDURE
+         ClassDB.declineUpdate('UPDATE', 'ClassDB.ConnectionActivity');
+   END IF;
+
+END
+$$;
+
+
+
+-------------- Start definition of view User on this line ---------------------
+
+
+
+
+
+
+COMMIT;

--- a/src/addUserMgmt.sql
+++ b/src/addUserMgmt.sql
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS ClassDB.DDLActivity
 -- prevent everyone else from doing anything with the table, except permit
 -- instructors and DB managers to read rows
 -- this pattern of ownership and grant/revoke applies to all objects defined in
--- this script: for brevity, such code is not prefaced ain with comments unless
+-- this script: for brevity, such code is not prefaced again with comments unless
 -- the code does something significantly different
 ALTER TABLE ClassDB.DDLActivity OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.DDLActivity FROM PUBLIC;
@@ -71,7 +71,7 @@ GRANT SELECT ON ClassDB.DDLActivity TO ClassDB_Instructor, ClassDB_DBManager;
 --Define a table to record connection activity of users
 -- no primary key is defined because there are no viable key attributes, and
 -- there is no benefit to having a primary key
--- UserName is not constrained to known users because DDL activity may be
+-- UserName is not constrained to known users because connection activity may be
 -- maintained for users who are no longer known, but see trigger definitions
 CREATE TABLE IF NOT EXISTS ClassDB.ConnectionActivity
 (
@@ -190,10 +190,27 @@ $$;
 
 
 
--------------- Start definition of view User on this line ---------------------
+--Define a view to return known users
+-- the fields marked TBD are yet to be filled in: they are commented out so
+-- the view definition can be replaced later
+CREATE OR REPLACE VIEW ClassDB.User AS
+SELECT
+   RoleName AS UserName, FullName, SchemaName, ExtraInfo,
+   ClassDB.isMember(RoleName, 'classdb_instructor') AS IsInstructor,
+   ClassDB.isMember(RoleName, 'classdb_student') AS IsStudent,
+   ClassDB.isMember(RoleName, 'classdb_dbmanager') AS IsDBManager,
+   ClassDB.hasClassDBRole(RoleName) AS HasClassDBRole
+   --0 AS DDLCount,              --TBD
+   --NULL AS LastDDLObject,      --TBD
+   --NULL AS LastDDLActivityAt,  --TBD
+   --0 AS ConnectionCount,       --TBD
+   --NULL AS LastConnectionAtUTC --TBD
+FROM ClassDB.RoleBase
+WHERE NOT IsTeam;
 
-
-
+ALTER VIEW ClassDB.User OWNER TO ClassDB;
+REVOKE ALL PRIVILEGES ON ClassDB.User FROM PUBLIC;
+GRANT SELECT ON ClassDB.User TO ClassDB_Instructor, ClassDB_DBManager;
 
 
 

--- a/tests/testRoleBaseMgmt.sql
+++ b/tests/testRoleBaseMgmt.sql
@@ -199,22 +199,40 @@ BEGIN
 --------------------------------------------------------------------------------
 
    --test dropping a role without dropping it from the server
-   --also test object assignment to another user
+   --also test object assignment to another user when ClassDB does not have the
+   --same rights as both the role to be dropped and the new object owner
+
+   --revoke u1 and s1 roles from ClassDB: dropRole should re-grant the roles
+   REVOKE u1, s1 FROM ClassDB;
+
+   --ClassDB does not have either role
+   RAISE INFO '%   isMember(ClassDB, u1: before dropRole)',
+   CASE ClassDB.isMember('classdb', 'u1') WHEN TRUE THEN 'FAIL: Code 24' ELSE 'PASS' END;
+
+   RAISE INFO '%   isMember(ClassDB, s1: before dropRole)',
+   CASE ClassDB.isMember('classdb', 's1') WHEN TRUE THEN 'FAIL: Code 25' ELSE 'PASS' END;
 
    --u1 is a known role
    RAISE INFO '%   isRoleKnown(u1: before dropRole)',
-   CASE ClassDB.isRoleKnown('u1') WHEN TRUE THEN 'PASS' ELSE 'FAIL: Code 24' END;
+   CASE ClassDB.isRoleKnown('u1') WHEN TRUE THEN 'PASS' ELSE 'FAIL: Code 26' END;
 
    --drop u1 from record, but let it remain a server role; assign objects to s1
    PERFORM ClassDB.dropRole('u1', FALSE, FALSE, 'assign', 's1');
 
    --u1 is no longer a known role
    RAISE INFO '%   isRoleKnown(u1: after dropRole)',
-   CASE ClassDB.isRoleKnown('u1') WHEN TRUE THEN 'FAIL: Code 25' ELSE 'PASS' END;
+   CASE ClassDB.isRoleKnown('u1') WHEN TRUE THEN 'FAIL: Code 27' ELSE 'PASS' END;
 
    --u1 is still a server role
    RAISE INFO '%   isServerRoleDefined(u1: after dropRole)',
-   CASE ClassDB.isServerRoleDefined('u1') WHEN TRUE THEN 'PASS' ELSE 'FAIL: Code 26' END;
+   CASE ClassDB.isServerRoleDefined('u1') WHEN TRUE THEN 'PASS' ELSE 'FAIL: Code 28' END;
+
+   --ClassDB should now have both u1 and s1 roles
+   RAISE INFO '%   isMember(ClassDB, u1: after dropRole)',
+   CASE ClassDB.isMember('classdb', 'u1') WHEN TRUE THEN 'PASS' ELSE 'FAIL: Code 29' END;
+
+   RAISE INFO '%   isMember(ClassDB, s1: after dropRole)',
+   CASE ClassDB.isMember('classdb', 's1') WHEN TRUE THEN 'PASS' ELSE 'FAIL: Code 30' END;
 
    --u1's schema exists but is now owned by s1
    RAISE INFO '%   dropRole(u1, FALSE, FALSE, assign, s1)',
@@ -222,7 +240,7 @@ BEGIN
                WHERE schema_name = 'u1' AND schema_owner = 's1'
               )
       WHEN TRUE THEN 'PASS'
-      ELSE 'FAIL: Code 27'
+      ELSE 'FAIL: Code 31'
    END;
 
 --------------------------------------------------------------------------------
@@ -232,18 +250,18 @@ BEGIN
 
    --t1 is a known role
    RAISE INFO '%   isRoleKnown(t1: before dropRole)',
-   CASE ClassDB.isRoleKnown('t1') WHEN TRUE THEN 'PASS' ELSE 'FAIL: Code 28' END;
+   CASE ClassDB.isRoleKnown('t1') WHEN TRUE THEN 'PASS' ELSE 'FAIL: Code 32' END;
 
    --drop u1 from record and from the server; assign objects to ClassDB_Instructor
    PERFORM ClassDB.dropRole('t1', TRUE);
 
    --t1 is no longer a known role
    RAISE INFO '%   isRoleKnown(u1: after dropRole)',
-   CASE ClassDB.isRoleKnown('t1') WHEN TRUE THEN 'FAIL: Code 29' ELSE 'PASS' END;
+   CASE ClassDB.isRoleKnown('t1') WHEN TRUE THEN 'FAIL: Code 33' ELSE 'PASS' END;
 
    --t1 is no longer a server role
    RAISE INFO '%   isServerRoleDefined(u1: after dropRole)',
-   CASE ClassDB.isServerRoleDefined('t1') WHEN TRUE THEN 'FAIL: Code 30' ELSE 'PASS' END;
+   CASE ClassDB.isServerRoleDefined('t1') WHEN TRUE THEN 'FAIL: Code 34' ELSE 'PASS' END;
 
    --t1's schema exists but is owned by classdb_instructor
    RAISE INFO '%   createRole(s1, s1 name, FALSE)',
@@ -251,35 +269,35 @@ BEGIN
                WHERE schema_name = 't1_schema' AND schema_owner = 'classdb_instructor'
               )
       WHEN TRUE THEN 'PASS'
-      ELSE 'FAIL: Code 31'
+      ELSE 'FAIL: Code 35'
    END;
 
 --------------------------------------------------------------------------------
 
    --test dropping a role while also dropping it from the server
-   --also drop roles objects
+   --also recursively drop all objects the role owns
 
    --s1 is a known role
    RAISE INFO '%   isRoleKnown(s1: before dropRole)',
-   CASE ClassDB.isRoleKnown('s1') WHEN TRUE THEN 'PASS' ELSE 'FAIL: Code 32' END;
+   CASE ClassDB.isRoleKnown('s1') WHEN TRUE THEN 'PASS' ELSE 'FAIL: Code 36' END;
 
    --drop s1 from record and the server, and drop all objects it owns
    PERFORM ClassDB.dropRole('s1', TRUE, FALSE, 'drop_c');
 
    --s1 is no longer a known role
    RAISE INFO '%   isRoleKnown(s1: after dropRole)',
-   CASE ClassDB.isRoleKnown('s1') WHEN TRUE THEN 'FAIL: Code 33' ELSE 'PASS' END;
+   CASE ClassDB.isRoleKnown('s1') WHEN TRUE THEN 'FAIL: Code 37' ELSE 'PASS' END;
 
    --s1 is no longer a server role
    RAISE INFO '%   isServerRoleDefined(s1: after dropRole)',
-   CASE ClassDB.isServerRoleDefined('s1') WHEN TRUE THEN 'FAIL: Code 34' ELSE 'PASS' END;
+   CASE ClassDB.isServerRoleDefined('s1') WHEN TRUE THEN 'FAIL: Code 38' ELSE 'PASS' END;
 
    --s1's schema does not exist
    RAISE INFO '%   dropRole(s1, TRUE, FALSE, drop_c)',
    CASE EXISTS(SELECT * FROM information_schema.schemata
                WHERE schema_owner = 's1'
               )
-      WHEN TRUE THEN 'FAIL: Code 35'
+      WHEN TRUE THEN 'FAIL: Code 39'
       ELSE 'PASS'
    END;
 

--- a/tests/testUserMgmt.sql
+++ b/tests/testUserMgmt.sql
@@ -66,17 +66,16 @@ BEGIN
    INSERT INTO ClassDB.ConnectionActivity
    VALUES ('u1', CURRENT_TIMESTAMP);
 
-   --DDLActivity should have one row
+   --ConnectionActivity should have one row
    RAISE INFO '%   COUNT(ClassDB.ConnectionActivity)',
       CASE (SELECT COUNT(*) FROM ClassDB.ConnectionActivity)
          WHEN 1 THEN 'PASS'
          ELSE 'FAIL: Code 3'
       END;
 
-   --drop test user: recursively drop all owned objects
-   PERFORM ClassDB.dropRole('u1', TRUE, TRUE, 'drop_c');
-
 END
 $$;
 
-COMMIT;
+
+--ignore all test data
+ROLLBACK;

--- a/tests/testUserMgmt.sql
+++ b/tests/testUserMgmt.sql
@@ -1,0 +1,82 @@
+--testUserMgmt.sql - ClassDB
+
+--Sean Murthy
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
+
+--(C) 2017- DASSL. ALL RIGHTS RESERVED.
+--Licensed to others under CC 4.0 BY-SA-NC
+--https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+--PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+
+--This script should be run as a superuser
+
+--This script tests the functionality in addUserMgmt.sql
+-- only nominal tests are covered presently
+-- need to plan a test for cases that should cause exceptions
+
+
+START TRANSACTION;
+
+--Tests for superuser privilege on current_user
+DO
+$$
+BEGIN
+   IF NOT ClassDB.isSuperUser() THEN
+      RAISE EXCEPTION 'Insufficient privileges: script must be run as a superuser';
+   END IF;
+END
+$$;
+
+
+DO
+$$
+BEGIN
+
+   --make sure the activity tables are empty
+   RAISE INFO '%   EXISTS(ClassDB.DDLActivity)',
+      CASE EXISTS(SELECT * FROM ClassDB.DDLActivity)
+         WHEN TRUE THEN 'FAIL: Code 1'
+         ELSE 'PASS'
+      END;
+
+   RAISE INFO '%   EXISTS(ClassDB.ConnectionActivity)',
+      CASE EXISTS(SELECT * FROM ClassDB.ConnectionActivity)
+         WHEN TRUE THEN 'FAIL: Code 2'
+         ELSE 'PASS'
+      END;
+
+   --create a new user: activities can only be inserted for known users
+   PERFORM ClassDB.createRole('u1', 'u1 name', FALSE);
+
+   --directly insert a row into DDLActivity
+   INSERT INTO ClassDB.DDLActivity
+   VALUES ('u1', CURRENT_TIMESTAMP, 'DROP TABLE', 'pg_temp.sample');
+
+   --DDLActivity should have one row
+   RAISE INFO '%   COUNT(ClassDB.DDLActivity)',
+      CASE (SELECT COUNT(*) FROM ClassDB.DDLActivity)
+         WHEN 1 THEN 'PASS'
+         ELSE 'FAIL: Code 3'
+      END;
+
+   --directly insert a row into ConnectionActivity
+   INSERT INTO ClassDB.ConnectionActivity
+   VALUES ('u1', CURRENT_TIMESTAMP);
+
+   --DDLActivity should have one row
+   RAISE INFO '%   COUNT(ClassDB.ConnectionActivity)',
+      CASE (SELECT COUNT(*) FROM ClassDB.ConnectionActivity)
+         WHEN 1 THEN 'PASS'
+         ELSE 'FAIL: Code 3'
+      END;
+
+   --drop test user: recursively drop all owned objects
+   PERFORM ClassDB.dropRole('u1', TRUE, TRUE, 'drop_c');
+
+END
+$$;
+
+COMMIT;


### PR DESCRIPTION
Commit b4f416c adds the initial version of `addUserMgmt.sql`. Commit 714774d adds `testUserMgmt.sql` containing some initial, rudimentary, nominal unit tests. 

**File `addUserMgmt.sql` needs a through review** because it has trigger definitions that can make or break the system. 

Commit 73e0f5f opportunistically adds a [test case previously identified](https://github.com/DASSL/ClassDB/pull/143#issuecomment-356129488).