### PR TITLE
Update privilege tests

### DIFF
--- a/tests/privileges/0_setup.sql
+++ b/tests/privileges/0_setup.sql
@@ -1,7 +1,8 @@
 --0_setup.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
---Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
 
 --(C) 2017- DASSL. ALL RIGHTS RESERVED.
 --Licensed to others under CC 4.0 BY-SA-NC
@@ -10,13 +11,18 @@
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
 
+START TRANSACTION;
+
+
 --Create Instructor, Student, and DBManager to login for testing purposes.
 -- The password for these users will be the same as their username
-SELECT classdb.createInstructor('ins0', 'NoName');
-SELECT classdb.createInstructor('ins1', 'NoName');
+SELECT ClassDB.createInstructor('ptins0', 'Instructor 0');
+SELECT ClassDB.createInstructor('ptins1', 'Instructor 1');
 
-SELECT classdb.createStudent('stu0', 'NoName');
-SELECT classdb.createStudent('stu1', 'NoName');
+SELECT ClassDB.createStudent('ptstu0', 'Student 0');
+SELECT ClassDB.createStudent('ptstu1', 'Student 1');
 
-SELECT classdb.createDBManager('dbm0');
-SELECT classdb.createDBManager('dbm1');
+SELECT ClassDB.createDBManager('ptdbm0', 'DB Manager 0');
+SELECT ClassDB.createDBManager('ptdbm1', 'DB Manager 1');
+
+COMMIT;

--- a/tests/privileges/1_instructorPass.sql
+++ b/tests/privileges/1_instructorPass.sql
@@ -1,7 +1,8 @@
 --1_instructorPass.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
---Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
 
 --(C) 2017- DASSL. ALL RIGHTS RESERVED.
 --Licensed to others under CC 4.0 BY-SA-NC
@@ -9,98 +10,107 @@
 
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
-
---Execute appropriate ClassDB functions (this is not inteded to test correctness of the
--- each function).
+START TRANSACTION;
 
 
-SELECT classdb.createStudent('teststu', 'noname');
-SELECT classdb.resetUserPassword('teststu');
-SELECT classdb.listUserConnections('teststu');
-SELECT classdb.killUserConnections('teststu');
-SELECT classdb.dropStudent('teststu');
+--Execute appropriate ClassDB functions (these tests do not verify correctness
+-- of each function)
+SELECT ClassDB.createStudent('teststu', 'noname');
+SELECT ClassDB.resetPassword('teststu');
+SELECT ClassDB.listUserConnections('teststu');
+SELECT ClassDB.killUserConnections('teststu');
+SELECT ClassDB.dropStudent('teststu', TRUE, TRUE, 'drop_c');
 
-SELECT classdb.createInstructor('testins', 'noname');
-SELECT classdb.dropInstructor('testins');
+--ClassDB.dropAllStudents is not being tested here because it would drop the
+-- test students that will later be used to connect to the DB
+--SELECT ClassDB.dropAllStudents(TRUE, TRUE, 'drop_c');
 
-SELECT classdb.createDBManager('testman', 'noname');
-SELECT classdb.dropDBManager('testman');
+SELECT ClassDB.createInstructor('testins', 'noname');
+SELECT ClassDB.dropInstructor('testins', TRUE, TRUE, 'drop_c');
+
+SELECT ClassDB.createDBManager('testman', 'noname');
+SELECT ClassDB.dropDBManager('testman', TRUE, TRUE, 'drop_c');
+
+SELECT ClassDB.importConnectionLog();
 
 
---CRUD on tables created by the instructor. This table should be placed in their own schema
--- and be accessed without needing to be fully schema qualified
-
+--CRUD on tables created by the instructor. This table should be placed in their
+-- own schema and be accessed without needing to be fully schema qualified
 --Create without schema qualification
-CREATE TABLE test
+CREATE TABLE Test
 (
-   col1 VARCHAR(10)
+   Col1 VARCHAR(10)
 );
 
---Insert with schema qualification - ensures test was created in the ins0 schema
-INSERT INTO ins0.test VALUES ('hello');
+--Insert with schema qualification - ensures test table was created in the
+-- ptins0 schema
+INSERT INTO ptins0.Test VALUES ('hello');
 
 --Select
-SELECT * FROM test;
+SELECT * FROM Test;
 
 --Update
-UPDATE test
-SET col1 = 'goodbye'
-WHERE TRUE;
+UPDATE Test
+SET Col1 = 'goodbye';
 
 --Delete
-DELETE FROM test;
-
-DROP TABLE test;
+DELETE FROM Test;
+DROP TABLE Test;
 
 
 --CRUD on public schema
-CREATE TABLE public.pubTest
+CREATE TABLE public.PublicTest
 (
-   col1 VARCHAR(10)
+   Col1 VARCHAR(10)
 );
 
-INSERT INTO public.pubTest VALUES ('hello');
+INSERT INTO public.PublicTest VALUES ('hello');
 
-SELECT * FROM public.pubTest;
+SELECT * FROM public.PublicTest;
 
-UPDATE public.pubTest
-SET col1 = 'goodbye'
-WHERE TRUE;
+UPDATE public.PublicTest
+SET Col1 = 'goodbye';
 
-DELETE FROM public.pubTest;
-
-DROP TABLE public.pubTest;
+DELETE FROM public.PublicTest;
+DROP TABLE public.PublicTest;
 
 
---Read from columns in Student and Instructor tables
-SELECT * FROM classdb.Student;
-SELECT * FROM classdb.Instructor;
+--Read from columns in RoleBase table
+SELECT * FROM ClassDB.RoleBase;
 
 
---Update name and schoolID in Student table
-SELECT classdb.createStudent('teststu1', 'Nonme', '50124');
-
-UPDATE classdb.Student
-SET studentName = 'NoName', schoolID = '50125'
-WHERE userName = 'teststu1';
-
-SELECT classdb.dropStudent('teststu1');
+--Read from columns in User, Student, Instructor, and DBManager views
+SELECT * FROM ClassDB.User;
+SELECT * FROM ClassDB.DBManager;
+SELECT * FROM ClassDB.Student;
+SELECT * FROM ClassDB.Instructor;
 
 
---Create table in public schema to test read privileges for Students and DBManagers
-DROP TABLE IF EXISTS public.testInsPub;
-CREATE TABLE public.testInsPub
+--Update FullName and ExtraInfo in RoleBase table
+SELECT ClassDB.createStudent('updateInfoTest', 'Temp name', NULL, 'Temp info');
+
+UPDATE ClassDB.RoleBase
+SET FullName = 'Updated name', ExtraInfo = 'Updated info'
+WHERE roleName = 'updateInfoTest';
+
+SELECT ClassDB.dropStudent('updateInfoTest', TRUE, TRUE, 'drop_c');
+
+
+--Create table in public schema to test read privileges for all users
+CREATE TABLE public.TestInsPublic
 (
-   col1 VARCHAR(20)
+   Col1 VARCHAR(20)
 );
 
-INSERT INTO public.testInsPub VALUES ('Read by: anyone');
+INSERT INTO public.testInsPublic VALUES ('Read by: anyone');
 
 --Create table in $user schema to test non-access for other roles
-DROP TABLE IF EXISTS testInsUsr;
-CREATE TABLE testInsUsr
+CREATE TABLE TestInsUsr
 (
    col1 VARCHAR(20)
 );
 
-INSERT INTO testInsUsr VALUES('Read by: no one');
+INSERT INTO testInsUsr VALUES('Read by: ptins0');
+
+
+COMMIT;

--- a/tests/privileges/2_studentPass.sql
+++ b/tests/privileges/2_studentPass.sql
@@ -1,7 +1,8 @@
 --2_studentPass.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
---Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
 
 --(C) 2017- DASSL. ALL RIGHTS RESERVED.
 --Licensed to others under CC 4.0 BY-SA-NC
@@ -9,9 +10,11 @@
 
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
+START TRANSACTION;
 
--- Execute meta functions
-CREATE TABLE test
+--Test catalog functions
+--Create table in student's schema
+CREATE TABLE Test
 (
    col1 VARCHAR(10)
 );
@@ -22,6 +25,12 @@ SELECT describe('test');
 DROP TABLE test;
 
 
+--Test frequent views access
+SELECT * FROM MyActivitySummary;
+SELECT * FROM MyDDLActivity;
+SELECT * FROM MyConnectionActivity;
+
+
 --CRUD on tables created by the student. This table should be placed in their own schema
 -- and be accessed without needing to be fully schema qualified
 --Create without schema qualification
@@ -30,8 +39,8 @@ CREATE TABLE test
    col1 VARCHAR(10)
 );
 
---Insert with schema qualification - ensures test was created in the stu0 schema
-INSERT INTO stu0.test VALUES ('hello');
+--Insert with schema qualification - ensures Test was created in ptstu0 schema
+INSERT INTO ptstu0.test VALUES ('hello');
 
 SELECT * FROM test;
 
@@ -40,20 +49,21 @@ SET col1 = 'goodbye'
 WHERE TRUE;
 
 DELETE FROM test;
-
 DROP TABLE test;
 
 
---Read on tables in the public schema created by Instructor (should return 1 row)
-SELECT * FROM testInsPub;
+--Read on tables in the public schema created by Instructor
+SELECT * FROM testInsPublic;
 
 
 --Create table in $user schema to test read privileges for Instructors and non-
 -- access for DBManagers and other students
-DROP TABLE IF EXISTS testStuUsr;
 CREATE TABLE testStuUsr
 (
    col1 VARCHAR(20)
 );
 
 INSERT INTO testStuUsr VALUES ('Read by: Instructor');
+
+
+COMMIT;

--- a/tests/privileges/3_dbmanagerPass.sql
+++ b/tests/privileges/3_dbmanagerPass.sql
@@ -1,7 +1,8 @@
 --3_dbmanagerPass.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
---Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
 
 --(C) 2017- DASSL. ALL RIGHTS RESERVED.
 --Licensed to others under CC 4.0 BY-SA-NC
@@ -10,70 +11,80 @@
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
 
---Execute appropriate ClassDB functions (this is not inteded to test correctness of the
--- each function).
+START TRANSACTION;
+
+--Execute appropriate ClassDB functions (these tests do not verify correctness
+-- of each function)
+SELECT ClassDB.createStudent('teststu', 'noname');
+SELECT ClassDB.resetPassword('teststu');
+SELECT ClassDB.listUserConnections('teststu');
+SELECT ClassDB.killUserConnections('teststu');
+SELECT ClassDB.dropStudent('teststu', TRUE, TRUE, 'drop_c');
+
+--ClassDB.dropAllStudents is not being tested here because it would drop the
+-- test students that will later be used to connect to the DB
+--SELECT ClassDB.dropAllStudents(TRUE, TRUE, 'drop_c');
+
+SELECT ClassDB.createInstructor('testins', 'noname');
+SELECT ClassDB.dropInstructor('testins', TRUE, TRUE, 'drop_c');
+
+SELECT ClassDB.createDBManager('testman', 'noname');
+SELECT ClassDB.dropDBManager('testman', TRUE, TRUE, 'drop_c');
+
+SELECT ClassDB.importConnectionLog();
 
 
-SELECT classdb.createStudent('teststu', 'noname');
-SELECT classdb.resetUserPassword('teststu');
-SELECT classdb.listUserConnections('teststu');
-SELECT classdb.killUserConnections('teststu');
-SELECT classdb.dropStudent('teststu');
-
-SELECT classdb.createInstructor('testins', 'noname');
-SELECT classdb.dropInstructor('testins');
-
-SELECT classdb.createDBManager('testman', 'noname');
-SELECT classdb.dropDBManager('testman');
-
-
---CRUD on tables created by the DBManager. This table should be placed in their 
+--CRUD on tables created by the DBManager. This table should be placed in their
 -- own schema and be accessed without needing to be fully schema qualified
-
 --Create without schema qualification
-CREATE TABLE test
+CREATE TABLE Test
 (
    col1 VARCHAR(10)
 );
 
---Insert with schema qualification - ensures test was created in the dbm0 schema
-INSERT INTO dbm0.test VALUES ('hello');
+--Insert with schema qualification - ensures test was created in the ptdbm0 schema
+INSERT INTO ptdbm0.Test VALUES ('hello');
 
-SELECT * FROM test;
+SELECT * FROM Test;
 
-UPDATE test
-SET col1 = 'goodbye'
-WHERE TRUE;
+UPDATE Test
+SET col1 = 'goodbye';
 
-DELETE FROM test;
-
-DROP TABLE test;
+DELETE FROM Test;
+DROP TABLE Test;
 
 
---Read from columns in Student and Instructor tables
-SELECT * FROM classdb.Student;
-SELECT * FROM classdb.Instructor;
+--Read from columns in RoleBase table
+SELECT * FROM ClassDB.RoleBase;
 
 
---Update name and schoolID in Student table
-SELECT classdb.createStudent('teststu', 'Nonme', '50124');
-
-UPDATE classdb.Student
-SET studentName = 'NoName', schoolID = '50125'
-WHERE userName = 'teststu';
-
-SELECT classdb.dropStudent('teststu');
+--Read from columns in User, Student, Instructor, and DBManager views
+SELECT * FROM ClassDB.User;
+SELECT * FROM ClassDB.DBManager;
+SELECT * FROM ClassDB.Student;
+SELECT * FROM ClassDB.Instructor;
 
 
---Read on tables in the public schema created by Instructor (should return 1 row)
-SELECT * FROM public.testInsPub;
+--Update FullName and ExtraInfo in RoleBase table
+SELECT ClassDB.createStudent('updateInfoTest', 'Temp name', NULL, 'Temp info');
+
+UPDATE ClassDB.RoleBase
+SET FullName = 'Updated name', ExtraInfo = 'Updated info'
+WHERE roleName = 'updateInfoTest';
+
+SELECT ClassDB.dropStudent('updateInfoTest', TRUE, TRUE, 'drop_c');
+
+
+--Read on tables in public schema created by Instructor (should return 1 row)
+SELECT * FROM public.testInsPublic;
 
 
 --Create table in $user schema to test non-access for other roles
-DROP TABLE IF EXISTS testDbmUsr;
 CREATE TABLE testDbmUsr
 (
    col1 VARCHAR(20)
 );
 
-INSERT INTO testDbmUsr VALUES('Read by: no one');
+INSERT INTO testDbmUsr VALUES('Read by: ptdbm0');
+
+COMMIT;

--- a/tests/privileges/4_instructorPass2.sql
+++ b/tests/privileges/4_instructorPass2.sql
@@ -1,7 +1,8 @@
 --4_instructorPass2.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
---Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
 
 --(C) 2017- DASSL. ALL RIGHTS RESERVED.
 --Licensed to others under CC 4.0 BY-SA-NC
@@ -10,12 +11,20 @@
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
 
+--This second instructor script tests the ability for the instructor to read
+-- from student schemas
+
+START TRANSACTION;
+
+
 --Read the $user schema of a student (should return one row)
-SELECT * FROM stu0.testStuUsr;
+SELECT * FROM ptstu0.testStuUsr;
 
 -- Execute meta functions
 SELECT listTables();
-SELECT listTables('stu0');
+SELECT listTables('ptstu0');
 
 SELECT describe('testInsPub', 'public');
-SELECT describe('testStuUsr', 'stu0');
+SELECT describe('testStuUsr', 'ptstu0');
+
+COMMIT;

--- a/tests/privileges/5_instructorFail.sql
+++ b/tests/privileges/5_instructorFail.sql
@@ -1,7 +1,8 @@
 --5_instructorFail.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
---Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
 
 --(C) 2017- DASSL. ALL RIGHTS RESERVED.
 --Licensed to others under CC 4.0 BY-SA-NC
@@ -10,63 +11,131 @@
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
 
---Not modify username or logging columns in Student and instructor tables
-UPDATE classdb.Student
-SET userName = 'diffName'
-WHERE userName = 'stu0';
+--Not insert or delete from RoleBase table, or update unallowed columns
+INSERT INTO ClassDB.RoleBase VALUES('testRole', 'Test name', FALSE,
+                                    'Test schema', 'Test info');
 
-UPDATE classdb.Student
-SET lastddlactivity = '2017-06-30'
-WHERE userName = 'stu0';
+DELETE FROM ClassDB.RoleBase
+WHERE RoleName = 'ptstu0';
 
-UPDATE classdb.Student
-SET lastddloperation = 'CREATE TABLE'
-WHERE userName = 'stu0';
+UPDATE ClassDB.RoleBase
+SET RoleName = 'diffName'
+WHERE RoleName = 'ptstu0';
 
-UPDATE classdb.Student
-SET lastddlobject = 'test'
-WHERE userName = 'stu0';
+UPDATE ClassDB.RoleBase
+SET IsTeam = TRUE
+WHERE RoleName = 'ptstu0';
 
-UPDATE classdb.Student
-SET ddlcount = 20
-WHERE userName = 'stu0';
-
-UPDATE classdb.Student
-SET lastconnection = '2017-06-30'
-WHERE userName = 'stu0';
-
-UPDATE classdb.Student
-SET connectioncount = 10
-WHERE userName = 'stu0';
-
---Not read other instructor or dbmanager tables
-SELECT * FROM ins0.testInsUsr;
-SELECT * FROM dbm0.testDbmUsr;
+UPDATE ClassDB.RoleBase
+SET SchemaName = 'diffSchema'
+WHERE RoleName = 'ptstu0';
 
 
---Not excute createUser function
-SELECT classdb.createUser('testusr', 'password');
+--Not insert, update, or delete from DDLActivity and ConnectionActivity tables
+INSERT INTO ClassDB.DDLActivity VALUES ('ptstu0', '2000-01-01 00:00',
+                                        'CREATE TABLE', 'ptstu0.myTable');
+
+UPDATE ClassDB.DDLActivity
+SET DDLOperation = 'DROP TABLE'
+WHERE UserName = 'ptstu0';
+
+DELETE FROM ClassDB.DDLActivity
+WHERE UserName = 'ptstu0';
+
+INSERT INTO ClassDB.ConnectionActivity VALUES ('ptsu0', '2000-01-01 00:00');
+
+UPDATE ClassDB.ConnectionActivity
+SET AcceptedAtUTC = '1999-12-31 00:00'
+WHERE UserName = 'ptstu0';
+
+DELETE FROM ClassDB.ConnectionActivity
+WHERE UserNAme = 'ptstu0';
 
 
---Not drop classdb functions (also covers ALTER and REPLACE)
-DROP FUNCTION IF EXISTS classdb.createUser(userName VARCHAR(63), initialPwd VARCHAR(128));
-DROP FUNCTION IF EXISTS classdb.createStudent(studentUserName VARCHAR(63),
-                        studentName VARCHAR(100), schoolID VARCHAR(20),
-                        initialPwd VARCHAR(128));
-DROP FUNCTION IF EXISTS classdb.createInstructor(instructorUserName VARCHAR(63),
-                        instructorName VARCHAR(100), initialPwd VARCHAR(128));
-DROP FUNCTION IF EXISTS classdb.createDBManager(managerUserName VARCHAR(63),
-                        initialPwd VARCHAR(128));
-DROP FUNCTION IF EXISTS classdb.dropStudent(userName VARCHAR(63));
-DROP FUNCTION IF EXISTS classdb.dropAllStudents();
-DROP FUNCTION IF EXISTS classdb.dropInstructor(userName VARCHAR(63));
-DROP FUNCTION IF EXISTS classdb.dropDBManager(userName VARCHAR(63));
-DROP FUNCTION IF EXISTS classdb.resetUserPassword(userName VARCHAR(63));
-DROP FUNCTION IF EXISTS classdb.listUserConnections(VARCHAR(63));
-DROP FUNCTION IF EXISTS classdb.killUserConnections(VARCHAR(63));
-DROP FUNCTION IF EXISTS classdb.killConnection(INT);
+--Not read other instructor or DB manager tables
+SELECT * FROM ptins0.testInsUsr;
+SELECT * FROM ptdbm0.testDbmUsr;
 
 
---Not drop meta functions (also covers ALTER and REPLACE)
-DROP FUNCTION IF EXISTS public.listTables(VARCHAR(63));
-DROP FUNCTION IF EXISTS public.describe(VARCHAR(63), VARCHAR(63));
+--Not execute internal functions
+SELECT ClassDB.createRole('testrole', 'Test name', FALSE);
+SELECT ClassDB.revokeClassDBRole('ptstu0', 'classdb_student');
+SELECT ClassDB.dropRole('ptstu0');
+SELECT ClassDB.logDDLActivity();
+SELECT ClassDB.rejectOperation();
+
+
+--Not drop ClassDB functions (also covers ALTER and REPLACE)
+DROP FUNCTION IF EXISTS classdb.cancreatedatabase(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.canlogin(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.changetimezone(TIMESTAMP, VARCHAR, VARCHAR);
+DROP FUNCTION IF EXISTS classdb.createdbmanager(ClassDB.IDNameDomain, VARCHAR,
+                                                ClassDB.IDNameDomain,VARCHAR,
+                                                BOOLEAN, BOOLEAN, VARCHAR);
+DROP FUNCTION IF EXISTS classdb.createinstructor(ClassDB.IDNameDomain, VARCHAR,
+                                                 ClassDB.IDNameDomain,VARCHAR,
+                                                 BOOLEAN, BOOLEAN, VARCHAR);
+DROP FUNCTION IF EXISTS classdb.createrole(ClassDB.IDNameDomain, VARCHAR,
+                                           BOOLEAN, ClassDB.IDNameDomain,
+                                           VARCHAR, BOOLEAN, BOOLEAN, VARCHAR);
+DROP FUNCTION IF EXISTS classdb.createstudent(ClassDB.IDNameDomain, VARCHAR,
+                                              ClassDB.IDNameDomain,VARCHAR,
+                                              BOOLEAN, BOOLEAN, VARCHAR);
+DROP FUNCTION IF EXISTS public.describe(VARCHAR, VARCHAR);
+DROP FUNCTION IF EXISTS public.describe(VARCHAR);
+DROP FUNCTION IF EXISTS classdb.disableddlactivitylogging();
+DROP FUNCTION IF EXISTS classdb.dropallstudents(BOOLEAN, BOOLEAN, VARCHAR,
+                                                ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.dropdbmanager(ClassDB.IDNameDomain, BOOLEAN,
+                                              BOOLEAN, VARCHAR,
+                                              ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.dropinstructor(ClassDB.IDNameDomain,BOOLEAN,
+                                               BOOLEAN, VARCHAR,
+                                               ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.droprole(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN,
+                                         VARCHAR, ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.dropstudent(ClassDB.IDNameDomain, BOOLEAN,
+                                            BOOLEAN, VARCHAR,
+                                            ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.enableddlactivitylogging();
+DROP FUNCTION IF EXISTS classdb.foldpgid(VARCHAR);
+DROP FUNCTION IF EXISTS public.foldpgid(VARCHAR);
+DROP FUNCTION IF EXISTS public.getmyactivity();
+DROP FUNCTION IF EXISTS public.getmyactivitysummary();
+DROP FUNCTION IF EXISTS public.getmyconnectionactivity();
+DROP FUNCTION IF EXISTS public.getmyddlactivity();
+DROP FUNCTION IF EXISTS classdb.getschemaname(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getschemaownername(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getuseractivity(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getuseractivitysummary(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getuserconnectionactivity(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getuserddlactivity(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.hasclassdbrole(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.hascreaterole(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.importconnectionlog(DATE);
+DROP FUNCTION IF EXISTS classdb.isclassdbrolename(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isdbmanager(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isinstructor(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.ismember(ClassDB.IDNameDomain,
+                                          ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isroleknown(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isserverroledefined(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isstudent(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.issuperuser(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isteam(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isuser(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.killconnection(INT4);
+DROP FUNCTION IF EXISTS classdb.killuserconnections(VARCHAR);
+DROP FUNCTION IF EXISTS classdb.listorphanobjects(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.listownedobjects(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS public.listtables(VARCHAR);
+DROP FUNCTION IF EXISTS classdb.listuserconnections(VARCHAR);
+DROP FUNCTION IF EXISTS classdb.logddlactivity();
+DROP FUNCTION IF EXISTS classdb.rejectoperation();
+DROP FUNCTION IF EXISTS classdb.resetpassword(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.revokeclassdbrole(ClassDB.IDNameDomain,
+                                                   ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.revokedbmanager(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.revokeinstructor(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.revokestudent(ClassDB.IDNameDomain);
+ 

--- a/tests/privileges/6_studentFail.sql
+++ b/tests/privileges/6_studentFail.sql
@@ -1,7 +1,8 @@
 --6_studentFail.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
---Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
 
 --(C) 2017- DASSL. ALL RIGHTS RESERVED.
 --Licensed to others under CC 4.0 BY-SA-NC
@@ -11,40 +12,40 @@
 
 
 --Not read tables in other users' schemas
-SELECT * FROM ins0.testInsUsr;
-SELECT * FROM stu0.testStuUsr;
-SELECT * FROM dbm0.testDbmUsr;
+SELECT * FROM ptins0.testInsUsr;
+SELECT * FROM ptstu0.testStuUsr;
+SELECT * FROM ptdbm0.testDbmUsr;
 
 
 --Not CUD on public schema
-INSERT INTO public.testInsPub VALUES ('Hello student');
+INSERT INTO public.testInsPublic VALUES ('Hello student');
 
-UPDATE public.testInsPub
-SET col1 = 'Hello'
-WHERE TRUE;
+UPDATE public.testInsPublic
+SET col1 = 'Hello';
 
-DELETE FROM public.testInsPub;
+DELETE FROM public.testInsPublic;
 
 
---Not execute any classdb functions
-SELECT classdb.createUser('testuser', 'password');
-SELECT classdb.dropUser('testuser');
+--Not access any objects in classdb schema, should be prevented by not having
+-- USAGE on the classdb schema anyway
+SELECT ClassDB.createUser('testuser', 'password');
+SELECT ClassDB.dropUser('testuser');
 
-SELECT classdb.createStudent('teststu', 'noname');
-SELECT classdb.resetUserPassword('teststu');
-SELECT classdb.listUserConnections('teststu');
-SELECT classdb.killUserConnections('teststu');
-SELECT classdb.dropStudent('teststu');
+SELECT ClassDB.createStudent('teststu', 'noname');
+SELECT ClassDB.resetUserPassword('teststu');
+SELECT ClassDB.listUserConnections('teststu');
+SELECT ClassDB.killUserConnections('teststu');
+SELECT ClassDB.dropStudent('teststu');
 
-SELECT classdb.createInstructor('testins', 'noname');
-SELECT classdb.dropInstructor('testins');
+SELECT ClassDB.createInstructor('testins', 'noname');
+SELECT ClassDB.dropInstructor('testins');
 
-SELECT classdb.createDBManager('testman', 'noname');
-SELECT classdb.dropDBManager('testman');
+SELECT ClassDB.createDBManager('testman', 'noname');
+SELECT ClassDB.dropDBManager('testman');
 
-SELECT classdb.dropAllStudents();
+SELECT ClassDB.dropAllStudents();
 
 
 --Not read Student or Instructor tables (non-access to classdb schema should also prevent this)
-SELECT * FROM classdb.Student;
-SELECT * FROM classdb.Instructor;
+SELECT * FROM ClassDB.Student;
+SELECT * FROM ClassDB.Instructor;

--- a/tests/privileges/7_dbmanagerFail.sql
+++ b/tests/privileges/7_dbmanagerFail.sql
@@ -1,7 +1,8 @@
 --7_dbmanagerFail.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
---Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
 
 --(C) 2017- DASSL. ALL RIGHTS RESERVED.
 --Licensed to others under CC 4.0 BY-SA-NC
@@ -10,68 +11,131 @@
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
 
---Not modify username or logging columns in Student and instructor tables
-UPDATE classdb.Student
-SET userName = 'diffName'
-WHERE userName = 'stu0';
+--Not insert or delete from RoleBase table, or update unallowed columns
+INSERT INTO ClassDB.RoleBase VALUES('testRole', 'Test name', FALSE,
+                                    'Test schema', 'Test info');
 
-UPDATE classdb.Student
-SET lastddlactivity = '2017-06-30'
-WHERE userName = 'stu0';
+DELETE FROM ClassDB.RoleBase
+WHERE RoleName = 'ptstu0';
 
-UPDATE classdb.Student
-SET lastddloperation = 'CREATE TABLE'
-WHERE userName = 'stu0';
+UPDATE ClassDB.RoleBase
+SET RoleName = 'diffName'
+WHERE RoleName = 'ptstu0';
 
-UPDATE classdb.Student
-SET lastddlobject = 'test'
-WHERE userName = 'stu0';
-
-UPDATE classdb.Student
-SET ddlcount = 20
-WHERE userName = 'stu0';
-
-UPDATE classdb.Student
-SET lastconnection = '2017-06-30'
-WHERE userName = 'stu0';
-
-UPDATE classdb.Student
-SET connectioncount = 10
-WHERE userName = 'stu0';
+UPDATE ClassDB.RoleBase
+SET IsTeam = TRUE
+WHERE RoleName = 'ptstu0';
 
 
---Not read Student's $user schemas
-SELECT * FROM stu0.testStuUsr;
+UPDATE ClassDB.RoleBase
+SET SchemaName = 'diffSchema'
+WHERE RoleName = 'ptstu0';
 
 
---Not read other instructors or dbmanagers tables
-SELECT * FROM ins0.testInsUsr;
-SELECT * FROM dbm0.testDbmUsr;
+--Not insert, update, or delete from DDLActivity and ConnectionActivity tables
+INSERT INTO ClassDB.DDLActivity VALUES ('ptstu0', '2000-01-01 00:00',
+                                        'CREATE TABLE', 'ptstu0.myTable');
+
+UPDATE ClassDB.DDLActivity
+SET DDLOperation = 'DROP TABLE'
+WHERE UserName = 'ptstu0';
+
+DELETE FROM ClassDB.DDLActivity
+WHERE UserName = 'ptstu0';
+
+INSERT INTO ClassDB.ConnectionActivity VALUES ('ptsu0', '2000-01-01 00:00');
+
+UPDATE ClassDB.ConnectionActivity
+SET AcceptedAtUTC = '1999-12-31 00:00'
+WHERE UserName = 'ptstu0';
+
+DELETE FROM ClassDB.ConnectionActivity
+WHERE UserNAme = 'ptstu0';
 
 
---Not excute createUser function
-SELECT classdb.createUser('testusr', 'password');
+--Not read other instructor or DB manager tables
+SELECT * FROM ptins0.testInsUsr;
+SELECT * FROM ptdbm0.testDbmUsr;
 
 
---Not drop classdb functions (also covers ALTER and REPLACE)
-DROP FUNCTION IF EXISTS classdb.createUser(userName VARCHAR(63), initialPwd VARCHAR(128));
-DROP FUNCTION IF EXISTS classdb.createStudent(studentUserName VARCHAR(63),
-                        studentName VARCHAR(100), schoolID VARCHAR(20),
-                        initialPwd VARCHAR(128));
-DROP FUNCTION IF EXISTS classdb.createInstructor(instructorUserName VARCHAR(63),
-                        instructorName VARCHAR(100), initialPwd VARCHAR(128));
-DROP FUNCTION IF EXISTS classdb.createDBManager(managerUserName VARCHAR(63),
-                        initialPwd VARCHAR(128));
-DROP FUNCTION IF EXISTS classdb.dropStudent(userName VARCHAR(63));
-DROP FUNCTION IF EXISTS classdb.dropAllStudents();
-DROP FUNCTION IF EXISTS classdb.dropInstructor(userName VARCHAR(63));
-DROP FUNCTION IF EXISTS classdb.dropDBManager(userName VARCHAR(63));
-DROP FUNCTION IF EXISTS classdb.resetUserPassword(userName VARCHAR(63));
-DROP FUNCTION IF EXISTS classdb.listUserConnections(VARCHAR(63));
-DROP FUNCTION IF EXISTS classdb.killUserConnections(VARCHAR(63));
-DROP FUNCTION IF EXISTS classdb.killConnection(INT);
+--Not execute internal functions
+SELECT ClassDB.createRole('testrole', 'Test name', FALSE);
+SELECT ClassDB.revokeClassDBRole('ptstu0', 'classdb_student');
+SELECT ClassDB.dropRole('ptstu0');
+SELECT ClassDB.logDDLActivity();
+SELECT ClassDB.rejectOperation();
 
 
---Not drop meta functions (also covers ALTER and REPLACE)
-DROP FUNCTION IF EXISTS public.listTables(VARCHAR(63));
-DROP FUNCTION IF EXISTS public.describe(VARCHAR(63), VARCHAR(63));
+--Not drop ClassDB functions (also covers ALTER and REPLACE)
+DROP FUNCTION IF EXISTS classdb.cancreatedatabase(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.canlogin(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.changetimezone(TIMESTAMP, VARCHAR, VARCHAR);
+DROP FUNCTION IF EXISTS classdb.createdbmanager(ClassDB.IDNameDomain, VARCHAR,
+                                                 ClassDB.IDNameDomain,VARCHAR,
+                                                 BOOLEAN, BOOLEAN, VARCHAR);
+DROP FUNCTION IF EXISTS classdb.createinstructor(ClassDB.IDNameDomain, VARCHAR,
+                                                  ClassDB.IDNameDomain,VARCHAR,
+                                                  BOOLEAN, BOOLEAN, VARCHAR);
+DROP FUNCTION IF EXISTS classdb.createrole(ClassDB.IDNameDomain, VARCHAR,
+                                            BOOLEAN, ClassDB.IDNameDomain,
+                                            VARCHAR, BOOLEAN, BOOLEAN, VARCHAR);
+DROP FUNCTION IF EXISTS classdb.createstudent(ClassDB.IDNameDomain, VARCHAR,
+                                               ClassDB.IDNameDomain,VARCHAR,
+                                               BOOLEAN, BOOLEAN, VARCHAR);
+DROP FUNCTION IF EXISTS public.describe(VARCHAR, VARCHAR);
+DROP FUNCTION IF EXISTS public.describe(VARCHAR);
+DROP FUNCTION IF EXISTS classdb.disableddlactivitylogging();
+DROP FUNCTION IF EXISTS classdb.dropallstudents(BOOLEAN, BOOLEAN, VARCHAR,
+                                                 ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.dropdbmanager(ClassDB.IDNameDomain, BOOLEAN,
+                                               BOOLEAN, VARCHAR,
+                                               ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.dropinstructor(ClassDB.IDNameDomain,BOOLEAN,
+                                                BOOLEAN, VARCHAR,
+                                                ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.droprole(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN,
+                                          VARCHAR, ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.dropstudent(ClassDB.IDNameDomain, BOOLEAN,
+                                             BOOLEAN, VARCHAR,
+                                             ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.enableddlactivitylogging();
+DROP FUNCTION IF EXISTS classdb.foldpgid(VARCHAR);
+DROP FUNCTION IF EXISTS public.foldpgid(VARCHAR);
+DROP FUNCTION IF EXISTS public.getmyactivity();
+DROP FUNCTION IF EXISTS public.getmyactivitysummary();
+DROP FUNCTION IF EXISTS public.getmyconnectionactivity();
+DROP FUNCTION IF EXISTS public.getmyddlactivity();
+DROP FUNCTION IF EXISTS classdb.getschemaname(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getschemaownername(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getuseractivity(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getuseractivitysummary(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getuserconnectionactivity(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getuserddlactivity(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.hasclassdbrole(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.hascreaterole(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.importconnectionlog(DATE);
+DROP FUNCTION IF EXISTS classdb.isclassdbrolename(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isdbmanager(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isinstructor(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.ismember(ClassDB.IDNameDomain,
+                                          ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isroleknown(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isserverroledefined(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isstudent(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.issuperuser(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isteam(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isuser(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.killconnection(INT4);
+DROP FUNCTION IF EXISTS classdb.killuserconnections(VARCHAR);
+DROP FUNCTION IF EXISTS classdb.listorphanobjects(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.listownedobjects(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS public.listtables(VARCHAR);
+DROP FUNCTION IF EXISTS classdb.listuserconnections(VARCHAR);
+DROP FUNCTION IF EXISTS classdb.logddlactivity();
+DROP FUNCTION IF EXISTS classdb.rejectoperation();
+DROP FUNCTION IF EXISTS classdb.resetpassword(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.revokeclassdbrole(ClassDB.IDNameDomain,
+                                                   ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.revokedbmanager(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.revokeinstructor(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.revokestudent(ClassDB.IDNameDomain);

--- a/tests/privileges/8_cleanup.sql
+++ b/tests/privileges/8_cleanup.sql
@@ -1,7 +1,8 @@
 --8_cleanup.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
---Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
 
 --(C) 2017- DASSL. ALL RIGHTS RESERVED.
 --Licensed to others under CC 4.0 BY-SA-NC
@@ -9,10 +10,10 @@
 
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
-DROP OWNED BY ins0;
-SELECT classdb.dropInstructor('ins0');
-SELECT classdb.dropInstructor('ins1');
-SELECT classdb.dropStudent('stu0');
-SELECT classdb.dropStudent('stu1');
-SELECT classdb.dropDBManager('dbm0');
-SELECT classdb.dropDBManager('dbm1');
+
+SELECT ClassDB.dropInstructor('ptins0', TRUE, TRUE, 'drop_c');
+SELECT ClassDB.dropInstructor('ptins1', TRUE, TRUE, 'drop_c');
+SELECT ClassDB.dropStudent('ptstu0', TRUE, TRUE, 'drop_c');
+SELECT ClassDB.dropStudent('ptstu1', TRUE, TRUE, 'drop_c');
+SELECT ClassDB.dropDBManager('ptdbm0', TRUE, TRUE, 'drop_c');
+SELECT ClassDB.dropDBManager('ptdbm1', TRUE, TRUE, 'drop_c');

--- a/tests/privileges/runAllPrivilegeTests.psql
+++ b/tests/privileges/runAllPrivilegeTests.psql
@@ -1,0 +1,58 @@
+--runAllPrivilegeTests.psql
+
+--Andrew Figueroa, Steven Rollo
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
+
+--(C) 2017- DASSL. ALL RIGHTS RESERVED.
+--Licensed to others under CC 4.0 BY-SA-NC
+--https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+--PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+--This psql script executes all of the privilege tests, pausing before each of
+-- the two sets: The first where all statements should succeed, and other
+-- where all statements should fail.
+
+
+--Remember the current user so we can switch back at the end
+-- Currently, this is assuming the starting superuser account is 'postgres'
+-- you must change this if you want to switch back to a different superuser account
+-- at the end of the script
+\set psqlCurrentUser postgres
+
+
+\echo 'The following tests should complete without any errors'
+\prompt 'Press enter to continue...' unusedInputVariable
+
+\i 0_setup.sql
+
+\connect - ptins0
+\i 1_instructorPass.sql
+
+\connect - ptstu0
+\i 2_studentPass.sql
+
+\connect - ptdbm0
+\i 3_dbmanagerPass.sql
+
+\connect - ptins1
+\i 4_instructorPass2.sql
+
+\echo 'README: If any previous test resulted in a warning, error, or exception, then privilege tests have failed'
+\echo 'All of the following tests should result in errors'
+\prompt 'Press enter to continue...' unusedInputVariable
+
+\i 5_instructorFail.sql
+
+\connect - ptstu1
+\i 6_studentFail.sql
+
+\connect - ptdbm1
+\i 7_dbmanagerFail.sql
+
+\echo 'Initiating cleanup'
+\prompt 'Press enter to continue...' unusedInputVariable
+
+\connect - :psqlCurrentUser
+\i 8_cleanup.sql

--- a/tests/privileges/testPrivilegesREADME.txt
+++ b/tests/privileges/testPrivilegesREADME.txt
@@ -1,7 +1,8 @@
 testPrivilegesREADME.txt - ClassDB
 
 Andrew Figueroa, Steven Rollo, Sean Murthy
-Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+Data Science & Systems Lab (DASSL)
+https://dassl.github.io/
 
 (C) 2017- DASSL. ALL RIGHTS RESERVED.
 Licensed to others under CC 4.0 BY-SA-NC
@@ -12,44 +13,57 @@ PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
 The files in this folder test the effective privileges of each role in ClassDB.
 Scripts that contain "Pass" in their file name are intended to run without issues,
-those that contain "Fail" should run only with issues (every statement should fail).
-These tests are only intended to examine the prvileges of each role, and not the
-functionality of any of ClassDB's facilities.
+those that contain "Fail" should run only with issues (every statement should 
+fail). These tests are only intended to examine the privileges of each role, and
+not the functionality of any of ClassDB's facilities.
 
-The files will be run in the order below, but it is necessary to switch users
-between the execution of each script.
+The files will be run in the order listed below, however, it is necessary to
+switch users between the execution of each script.
 
-Prior to running the 0_setup.sql script, run the full setup of ClassDB and stay 
-connected to database.
+Prior to running the 0_setup.sql script, it is recommended to use a full, but
+otherwise unmodified setup of ClassDB.It may be possible to test with
+only some or no reco or opt portions installed, or with the system having been,
+used but the outputs from running these tests will need to be interpreted
+differently, since different messages may be displayed.
+
+A script, runAllPrivilegeTests.psql, is included in the same directory as this
+README file that performs the necessary steps for testing in an automated
+manner. This script must be run with psql client. Additionally, the script
+assumes that the script is started by a user with the name postgres. If this is
+not true, the role name can be modified within that script. 
+
+---
+
+Steps for testing privileges:
 
 The 0_setup.sql script will create six users, two for each type of role. The 
 password for each of these test roles is the same as their user name.
 
-ins0, ins1 - Instructor
-stu0, stu1 - Student
-dbm0, dbm1 - DBManager
+ptins0, ptins1 - Instructor
+ptstu0, ptstu1 - Student
+ptdbm0, ptdbm1 - DBManager
 
 
 Run setup as a superuser, stay connected
 Execute: 0_setup.sql
 
-Switch to ins0
+Switch to ptins0
 Execute: 1_instructorPass.sql
 
-Switch to stu0
+Switch to ptstu0
 Execute: 2_studentPass.sql
 
-Switch to dbm0
+Switch to ptdbm0
 Execute: 3_dbmanagerPass.sql
 
-Switch to ins1
+Switch to ptins1
 Execute: 4_instructorPass2.sql
 Execute: 5_instructorFail.sql
 
-Switch to stu1
+Switch to ptstu1
 Execute: 6_studentFail.sql
 
-Switch to dbm1
+Switch to ptdbm1
 Execute: 7_dbmanagerFail.sql
 
 Switch back to superuser


### PR DESCRIPTION
Previously, none of the privilege tests functioned as they should since they were still using V1.0's API and objects. They have now been updated to work with M2 (V2.0), and have had new objects added to which privileges needed to be tested.

No issues have been identified with the current state of privileges. Also, no major issues were identified with the functionality of the system.

Additionally, running privilege tests no longer require the user to manually reconnect to the database and type in a script name. This is now taken care of by a `psql` script. The readme has also been updated to reflect this.

Many code-consistency fixes were also make to the tests themselves.

No modifications to the system were done in this PR.