### PR TITLE
Change default value of objectsDisposition in dropRole

### DIFF
--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -140,7 +140,7 @@ BEGIN
    $3 = ClassDB.getSchemaName($1);
 
    --grant server-level student group role to new student
-   EXECUTE FORMAT('GRANT ClassDB_Student TO %s', $1);
+   PERFORM ClassDB.grantRole('ClassDB_Student', $1);
 
    --set server-level client connection settings for the student
    EXECUTE FORMAT('ALTER ROLE %s CONNECTION LIMIT 5', $1);
@@ -308,7 +308,7 @@ BEGIN
    PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6, $7);
 
    --grant server-level instructor group role to new instructor
-   EXECUTE FORMAT('GRANT ClassDB_Instructor TO %s', $1);
+   PERFORM ClassDB.grantRole('ClassDB_Instructor', $1);
 
    --set privileges on future tables the instructor creates in 'public' schema
    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA public GRANT'
@@ -433,7 +433,7 @@ BEGIN
    PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6, $7);
 
    --grant server-level DB manager group role to new DB manager
-   EXECUTE FORMAT('GRANT ClassDB_DBManager TO %s', $1);
+   PERFORM ClassDB.grantRole('ClassDB_DBManager', $1);
 END;
 $$ LANGUAGE plpgsql
    SECURITY DEFINER;

--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -223,7 +223,7 @@ CREATE OR REPLACE FUNCTION
    ClassDB.dropStudent(userName ClassDB.IDNameDomain,
                        dropFromServer BOOLEAN DEFAULT FALSE,
                        okIfRemainsClassDBRoleMember BOOLEAN DEFAULT TRUE,
-                       objectsDisposition VARCHAR DEFAULT 'assign_i',
+                       objectsDisposition VARCHAR DEFAULT 'assign',
                        newObjectsOwnerName ClassDB.IDNameDomain DEFAULT NULL)
    RETURNS VOID AS
 $$
@@ -260,7 +260,7 @@ GRANT EXECUTE ON FUNCTION
 CREATE OR REPLACE FUNCTION
    ClassDB.dropAllStudents(dropFromServer BOOLEAN DEFAULT FALSE,
                            okIfRemainsClassDBRoleMember BOOLEAN DEFAULT TRUE,
-                           objectsDisposition VARCHAR DEFAULT 'assign_i',
+                           objectsDisposition VARCHAR DEFAULT 'assign',
                            newObjectsOwnerName ClassDB.IDNameDomain
                                                DEFAULT NULL)
    RETURNS VOID AS
@@ -381,7 +381,7 @@ CREATE OR REPLACE FUNCTION
    ClassDB.dropInstructor(userName ClassDB.IDNameDomain,
                           dropFromServer BOOLEAN DEFAULT FALSE,
                           okIfRemainsClassDBRoleMember BOOLEAN DEFAULT TRUE,
-                          objectsDisposition VARCHAR DEFAULT 'assign_i',
+                          objectsDisposition VARCHAR DEFAULT 'assign',
                           newObjectsOwnerName ClassDB.IDNameDomain DEFAULT NULL)
    RETURNS VOID AS
 $$
@@ -493,7 +493,7 @@ CREATE OR REPLACE FUNCTION
    ClassDB.dropDBManager(userName ClassDB.IDNameDomain,
                          dropFromServer BOOLEAN DEFAULT FALSE,
                          okIfRemainsClassDBRoleMember BOOLEAN DEFAULT TRUE,
-                         objectsDisposition VARCHAR DEFAULT 'assign_i',
+                         objectsDisposition VARCHAR DEFAULT 'assign',
                          newObjectsOwnerName ClassDB.IDNameDomain DEFAULT NULL)
    RETURNS VOID AS
 $$

--- a/src/db/core/addHelpersCore.sql
+++ b/src/db/core/addHelpersCore.sql
@@ -310,7 +310,43 @@ $$ LANGUAGE plpgsql
 ALTER FUNCTION ClassDB.canLogin(ClassDB.IDNameDomain) OWNER TO ClassDB;
 
 
---Define a function to list all  objects owned by some role. This query uses
+
+--Define a function to grant a role ("role") to another role ("receiver")
+-- current user is the default receiver
+-- grants role to receiver only if receiver is not already a member of the role
+-- raises a custom exception if grant fails due to insufficient privilege and
+-- includes the original error message as a hint
+-- re-raises all other exceptions
+-- this function must be VOLATILE; marking it STABLE raises the following exception
+--    ERROR: GRANT ROLE is not allowed in a non-volatile function
+--    SQL state: 0A000
+CREATE OR REPLACE FUNCTION
+   ClassDB.grantRole(roleName ClassDB.IDNameDomain,
+                     receiverName ClassDB.IDNameDomain DEFAULT CURRENT_USER
+                    )
+   RETURNS VOID AS
+$$
+BEGIN
+   IF NOT ClassDB.isMember($2, $1) THEN
+      EXECUTE FORMAT('GRANT %s TO %s', $1, $2);
+   END IF;
+EXCEPTION
+   WHEN insufficient_privilege THEN
+      RAISE EXCEPTION 'Insufficient privilege: Executing user % '
+                      'cannot grant role % to role %', CURRENT_USER, $1, $2
+                      USING HINT = SQLERRM;
+   WHEN OTHERS THEN
+      RAISE;
+END;
+$$ LANGUAGE plpgsql
+  RETURNS NULL ON NULL INPUT;
+
+ALTER FUNCTION ClassDB.grantRole(ClassDB.IDNameDomain, ClassDB.IDNameDomain)
+   OWNER TO ClassDB;
+
+
+
+--Define a function to list all objects owned by a role. This query uses
 -- pg_class which lists all objects Postgres considers relations (tables, views,
 -- and types) and UNIONs with pg_proc include functions
 --Postgres views are used because they contain the owner of each object
@@ -335,15 +371,15 @@ $$
       WHEN c.relkind = 'f' THEN 'Foreign Table'
       ELSE NULL
    END
-   FROM pg_class c --Join pg_roles and pg_namespace to get the names of the role and schema
-   JOIN pg_roles r ON r.oid = c.relowner
-   JOIN pg_namespace n ON n.oid = c.relnamespace
+   FROM pg_catalog.pg_class c
+   JOIN pg_catalog.pg_roles r ON r.oid = c.relowner
+   JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
    WHERE r.rolname = ClassDB.foldPgID($1)
    UNION ALL
    SELECT p.proname::VARCHAR(63), n.nspname::VARCHAR(63), 'Function'
-   FROM pg_proc p
-   JOIN pg_roles r ON r.oid = p.proowner
-   JOIN pg_namespace n ON n.oid = p.pronamespace
+   FROM pg_catalog.pg_proc p
+   JOIN pg_catalog.pg_roles r ON r.oid = p.proowner
+   JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
    WHERE r.rolname = ClassDB.foldPgID($1);
 $$ LANGUAGE sql
    STABLE
@@ -355,6 +391,7 @@ REVOKE ALL ON FUNCTION ClassDB.listOwnedObjects(ClassDB.IDNameDomain) FROM PUBLI
 
 GRANT EXECUTE ON FUNCTION ClassDB.listOwnedObjects(ClassDB.IDNameDomain)
       TO ClassDB_Instructor, ClassDB_DBManager;
+
 
 
 --Define a function to list all 'orphan' objects owned by ClassDB_Instructor and
@@ -403,9 +440,14 @@ GRANT EXECUTE ON FUNCTION ClassDB.listOrphanObjects(ClassDB.IDNameDomain)
       TO ClassDB_Instructor, ClassDB_DBManager;
 
 
+
 --Changes a timestamp in fromTimeZone to toTimeZone
-CREATE OR REPLACE FUNCTION ClassDB.changeTimeZone(ts TIMESTAMP,
-   toTimeZone VARCHAR DEFAULT TO_CHAR(CURRENT_TIMESTAMP, 'TZ'), fromTimeZone VARCHAR DEFAULT 'UTC')
+CREATE OR REPLACE FUNCTION
+   ClassDB.changeTimeZone
+   (ts TIMESTAMP,
+    toTimeZone VARCHAR DEFAULT TO_CHAR(CURRENT_TIMESTAMP, 'TZ'),
+    fromTimeZone VARCHAR DEFAULT 'UTC'
+   )
 RETURNS TIMESTAMP AS
 $$
    SELECT (ts AT TIME ZONE COALESCE(fromTimeZone, 'UTC')) AT TIME ZONE
@@ -416,6 +458,7 @@ $$ LANGUAGE sql
 ALTER FUNCTION
    ClassDB.ChangeTimeZone(ts TIMESTAMP, toTimeZone VARCHAR, fromTimeZone VARCHAR)
    OWNER TO ClassDB;
+
 
 
 --Define a function to retrieve specific capabilities a user has

--- a/src/db/core/addRoleBaseMgmtCore.sql
+++ b/src/db/core/addRoleBaseMgmtCore.sql
@@ -398,20 +398,24 @@ REVOKE ALL ON FUNCTION
 -- the role to unrecord does not have to be a server role
 -- if server role, can leave its objects as is, drop, or reassign to another role
 -- parameter objectsDisposition decides the action taken. possible values are:
---  'as_is', 'drop', 'drop_c' (drop cascade), 'assign', 'assign_i', 'assign_m'
+--  'as_is', 'drop', 'drop_c' (drop cascade), 'assign'
 --  underscore (_) may be replaced with a dash (-)
 --  the text/prefix 'assign' may be replaced with 'xfer'
 -- 'as_is' or 'drop' cannot be used if dropFromServer is TRUE
 -- parameter newObjectsOwnerName is used if objectsDisposition is 'assign'
+--  SESSION_USER is the default new owner but default value is NULL so a
+--  notice can be raised
 CREATE OR REPLACE FUNCTION
    ClassDB.dropRole(roleName ClassDB.IDNameDomain,
                     dropFromServer BOOLEAN DEFAULT FALSE,
                     okIfClassDBRoleMember BOOLEAN DEFAULT TRUE,
-                    objectsDisposition VARCHAR DEFAULT 'assign_i',
+                    objectsDisposition VARCHAR DEFAULT 'assign',
                     newObjectsOwnerName ClassDB.IDNameDomain DEFAULT NULL
                    )
    RETURNS VOID AS
 $$
+DECLARE
+   newOwnerName ClassDB.IDNameDomain;
 BEGIN
 
    --permit dropping only known roles
@@ -435,18 +439,42 @@ BEGIN
    END IF;
 
    --determine the disposition for objects the role owns
-   -- the default disposition is to assign ownership to role ClassDB_Instructor
+   -- the default disposition is to assign ownership to another role
    -- trim spaces, replace dash (-) with an underscore (_) to ease later testing
-   $4 = COALESCE(LOWER(REPLACE(TRIM($4), '-', '_')), 'assign_i');
+   $4 = COALESCE(LOWER(REPLACE(TRIM($4), '-', '_')), 'assign');
 
-   --objects cannot be left "as is" or just dropped if role is dropped from server
-   -- only drop-cascade and assignment guarantee the role no longer owns any object
-   IF ($2 AND $4 IN('as_is', 'drop')) THEN
-      RAISE EXCEPTION
-         'Invalid argument: disposition cannot be "%" if role dropped from server', $4;
+   --ensure disposition choice indicated is supported
+   IF ($4 NOT IN('as_is', 'drop', 'drop_c', 'assign', 'xfer')) THEN
+      RAISE EXCEPTION 'Invalid argument: disposition cannot be "%"', $4;
    END IF;
 
-   --enforce the disposition choice
+   -- objects cannot be left "as is" or just dropped if the role is also dropped
+   -- from the server, because only drop-cascade and assignment guarantee the
+   -- role being dropped no longer owns any object
+   IF $4 IN('as_is', 'drop') THEN
+      IF $2 THEN
+         RAISE EXCEPTION 'Invalid argument: disposition cannot be "%" if role is'
+                         'dropped from the server', $4;
+      END IF;
+   END IF;
+
+   --the new owner's name cannot be empty or same as that of a ClassDB role
+   -- also, the new owner should already be defined in the server
+   --using an IF block instead of ELSIF for clarity
+   IF ($4 IN ('assign', 'xfer') AND $5 IS NOT NULL) THEN
+      $5 = TRIM($5);
+      IF ($5 = '') THEN
+         RAISE EXCEPTION 'Invalid argument: new owner''s name is empty';
+      ELSIF(ClassDB.isClassDBRoleName($5) OR ClassDB.foldPgID($5) = 'classdb')
+      THEN
+         RAISE EXCEPTION 'Invalid argument: new owner cannot be "%"', $5;
+      ELSIF NOT ClassDB.isServerRoleDefined($5) THEN
+         RAISE EXCEPTION 'New owner role "%" is not defined', $5;
+      END IF;
+   END IF;
+
+
+   --all good, enforce the disposition choice
    IF ($4 <> 'as_is') THEN
 
       --give the executing user (should be 'classdb') same rights as role to drop
@@ -465,33 +493,22 @@ BEGIN
                     CASE $4 WHEN 'drop' THEN 'RESTRICT' ELSE 'CASCADE' END
                   );
       ELSE
-         --reassign ownership: determine the name of the new owner of objects
-         $5 = CASE
-               WHEN $4 IN ('assign', 'xfer') THEN TRIM($5)
-               WHEN $4 IN ('assign_m', 'xfer_m') THEN 'classdb_dbmanager'
-               ELSE 'classdb_instructor'
-              END;
-
-         --determine if the new owner's name is valid
-         IF ($5 = '' OR $5 IS NULL) THEN
-            RAISE EXCEPTION 'Invalid argument: new owner''s name is empty or NULL';
-         END IF;
-
-         --test if the new owner exists in the server
-         IF NOT ClassDB.isServerRoleDefined($5) THEN
-            RAISE EXCEPTION 'New owner role "%" is not defined', $5;
-         END IF;
-
-         IF NOT ClassDB.isMember(CURRENT_USER::ClassDB.IDNameDomain, $1) THEN
-            EXECUTE FORMAT('GRANT %s TO CURRENT_USER', $1);
-         END IF;
+         --make SESSION_USER the new owner if no new owner is specified
+         newOwnerName = COALESCE($5, SESSION_USER);
 
          --xfer ownership of objects owned by role in question to the new owner
          -- grant the executing user the same rights as new owner prior to xfer
-         IF NOT ClassDB.isMember(CURRENT_USER::ClassDB.IDNameDomain, $5) THEN
-            EXECUTE FORMAT('GRANT %s TO CURRENT_USER', $5);
+         IF NOT ClassDB.isMember(CURRENT_USER::ClassDB.IDNameDomain, newOwnerName)
+         THEN
+            EXECUTE FORMAT('GRANT %s TO CURRENT_USER', newOwnerName);
          END IF;
-         EXECUTE FORMAT('REASSIGN OWNED BY %s TO %s', $1, $5);
+         EXECUTE FORMAT('REASSIGN OWNED BY %s TO %s', $1, newOwnerName);
+
+         --inform if a new owner was not provided
+         IF $5 IS NULL THEN
+            RAISE NOTICE 'Objects owned by "%" are reassigned to "%"',
+                         $1, newOwnerName;
+         END IF;
       END IF;
 
    END IF; --end of object disposition

--- a/src/db/core/addRoleBaseMgmtCore.sql
+++ b/src/db/core/addRoleBaseMgmtCore.sql
@@ -500,10 +500,10 @@ BEGIN
          PERFORM ClassDB.grantRole(newOwnerName);
          EXECUTE FORMAT('REASSIGN OWNED BY %s TO %s', $1, newOwnerName);
 
-         --inform if new owner's name wasn'o't supplied: must test parameter supplied
+         --inform if new owner's name wasn't supplied: must test the parameter
          IF $5 IS NULL THEN
-            RAISE INFO 'Objects owned by "%" are reassigned to "%"',
-                       $1, newOwnerName;
+            RAISE NOTICE 'Objects owned by % are reassigned to %',
+                         $1, newOwnerName;
          END IF;
       END IF;
 

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -438,7 +438,7 @@ BEGIN
    IF EXISTS(
       SELECT * FROM pg_catalog.pg_roles
       WHERE RolName IN ('testdbm0', 'testdbm1', 'testdbm2', 'testdbm3',
-                        'testdbmdbm0', 'testdbm4')
+                        'testdbmstu0', 'testdbm4')
             AND NOT RolCanLogin
             )
    THEN
@@ -689,6 +689,13 @@ BEGIN
    SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.createDBManager('testStuDBM0', 'Test student/DB manager 0');
    RESET client_min_messages;
+   
+   --Create DB manager to handle default object disposition
+   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');  
+   SET SESSION AUTHORIZATION tempDBM0;
+   
+   --Suppress NOTICEs about ownership reassignment
+   SET SESSION client_min_messages TO WARNING;
 
    --Drop first student
    PERFORM ClassDB.dropStudent('testStu0');
@@ -696,24 +703,30 @@ BEGIN
    --Drop second student, including dropping from server
    PERFORM ClassDB.dropStudent('testStu1', TRUE);
 
-   --Drop server role for third student, then drop using ClassDB means
+   --Manually server role for third student (must be done as superuser), then
+   -- from ClassDB (as instructor again)
+   RESET SESSION AUTHORIZATION;
    DROP OWNED BY testStu2;
    DROP ROLE testStu2;
-   SET LOCAL client_min_messages TO WARNING;
+
+   SET SESSION AUTHORIZATION tempDBM0;
    PERFORM ClassDB.dropStudent('testStu2');
-   RESET client_min_messages;
 
    --Drop server role and owned objects for fourth student
    PERFORM ClassDB.dropStudent('testStu3', TRUE, TRUE, 'drop_c');
 
-   --Drop fifth student
+   --Drop fifth student, who has an additional non-ClassDB schema
    PERFORM ClassDB.dropStudent('testStu4');
 
    --Drop multi-role student
-   SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.dropStudent('testStuDBM0');
-   RESET client_min_messages;
 
+   --Switch back to superuser role before validating test cases
+   RESET SESSION AUTHORIZATION;
+   
+   --Turn all messages back on
+   RESET client_min_messages;
+   
    --Check for correct existence of roles
    IF    NOT ClassDB.isServerRoleDefined('testStu0')
       OR ClassDB.isServerRoleDefined('testStu1')
@@ -738,19 +751,19 @@ BEGIN
    END IF;
 
    --Check for ownership of existing schemas
-   IF NOT(ClassDB.getSchemaOwnerName('testStu0') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testStu1') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testStu4') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testSchema') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testStuDBM0') = 'classdb_instructor')
+   IF NOT(ClassDB.getSchemaOwnerName('testStu0') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testStu1') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testStu4') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testSchema') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testStuDBM0') = 'tempdbm0')
    THEN
       RETURN 'FAIL: Code 3';
    END IF;
 
    --Cleanup
-   DROP ROLE testStu0, testStu4, testStuDBM0;
-   DROP SCHEMA testStu0 ,testStu1, testStu4, testSchema, testStuDBM0;
-   DELETE FROM ClassDB.RoleBase WHERE RoleName = 'teststudbm0';
+   DROP OWNED BY tempDBM0;
+   DROP ROLE testStu0, testStu4, testStuDBM0, tempDBM0;
+   DELETE FROM ClassDB.RoleBase WHERE RoleName IN ('teststudbm0', 'tempdbm0');
 
    RETURN 'PASS';
 END;
@@ -777,6 +790,13 @@ BEGIN
    SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.createDBManager('testInsDBM0', 'Test instructor/DB manager 0');
    RESET client_min_messages;
+   
+   --Create DB manager to handle default object disposition
+   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');  
+   SET SESSION AUTHORIZATION tempDBM0;
+   
+   --Suppress NOTICEs about ownership reassignment
+   SET SESSION client_min_messages TO WARNING;
 
    --Drop first instructor
    PERFORM ClassDB.dropInstructor('testIns0');
@@ -784,24 +804,30 @@ BEGIN
    --Drop second instructor, including dropping from server
    PERFORM ClassDB.dropInstructor('testIns1', TRUE);
 
-   --Drop server role for third instructor, then drop using ClassDB means
+   --Manually server role for third instructor (must be done as superuser), then
+   -- from ClassDB (as instructor again)
+   RESET SESSION AUTHORIZATION;
    DROP OWNED BY testIns2;
    DROP ROLE testIns2;
-   SET LOCAL client_min_messages TO WARNING;
+
+   SET SESSION AUTHORIZATION tempDBM0;
    PERFORM ClassDB.dropInstructor('testIns2');
-   RESET client_min_messages;
 
    --Drop server role and owned objects for fourth instructor
    PERFORM ClassDB.dropInstructor('testIns3', TRUE, TRUE, 'drop_c');
 
-   --Drop fifth instructor
+   --Drop fifth instructor, who has an additional non-ClassDB schema
    PERFORM ClassDB.dropInstructor('testIns4');
 
    --Drop multi-role instructor
-   SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.dropInstructor('testInsDBM0');
-   RESET client_min_messages;
 
+   --Switch back to superuser role before validating test cases
+   RESET SESSION AUTHORIZATION;
+   
+   --Turn all messages back on
+   RESET client_min_messages;
+   
    --Check for correct existence of roles
    IF    NOT ClassDB.isServerRoleDefined('testIns0')
       OR ClassDB.isServerRoleDefined('testIns1')
@@ -826,19 +852,19 @@ BEGIN
    END IF;
 
    --Check for ownership of existing schemas
-   IF NOT(ClassDB.getSchemaOwnerName('testIns0') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testIns1') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testIns4') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testSchema') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testInsDBM0') = 'classdb_instructor')
+   IF NOT(ClassDB.getSchemaOwnerName('testIns0') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testIns1') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testIns4') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testSchema') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testInsDBM0') = 'tempdbm0')
    THEN
       RETURN 'FAIL: Code 3';
    END IF;
 
    --Cleanup
-   DROP ROLE testIns0, testIns4, testInsDBM0;
-   DROP SCHEMA testIns0 ,testIns1, testIns4, testSchema, testInsDBM0;
-   DELETE FROM ClassDB.RoleBase WHERE RoleName = 'testinsdbm0';
+   DROP OWNED BY tempDBM0;
+   DROP ROLE testIns0, testIns4, testInsDBM0, tempDBM0;
+   DELETE FROM ClassDB.RoleBase WHERE RoleName IN ('testinsdbm0', 'tempdbm0');
 
    RETURN 'PASS';
 END;
@@ -860,11 +886,18 @@ BEGIN
    CREATE SCHEMA testSchema AUTHORIZATION testDBM1;
 
    --Multi-role user
-   PERFORM ClassDB.createDBManager('testDBMStu0', 'Test DB manager/student 0',
+   PERFORM ClassDB.createDBManager('testDBMStu0', 'Test DB manager/Student 0',
                                  NULL, NULL, FALSE, FALSE);
    SET LOCAL client_min_messages TO WARNING;
-   PERFORM ClassDB.createDBManager('testDBMStu0', 'Test DB manager/student 0');
+   PERFORM ClassDB.createStudent('testDBMStu0', 'Test DB manager/Student 0');
    RESET client_min_messages;
+   
+   --Create DB manager to handle default object disposition
+   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');  
+   SET SESSION AUTHORIZATION tempDBM0;
+   
+   --Suppress NOTICEs about ownership reassignment
+   SET SESSION client_min_messages TO WARNING;
 
    --Drop first DB manager
    PERFORM ClassDB.dropDBManager('testDBM0');
@@ -872,24 +905,30 @@ BEGIN
    --Drop second DB manager, including dropping from server
    PERFORM ClassDB.dropDBManager('testDBM1', TRUE);
 
-   --Drop server role for third DB manager, then drop using ClassDB means
+   --Manually server role for third DB manager (must be done as superuser), then
+   -- from ClassDB (as instructor again)
+   RESET SESSION AUTHORIZATION;
    DROP OWNED BY testDBM2;
    DROP ROLE testDBM2;
-   SET LOCAL client_min_messages TO WARNING;
+
+   SET SESSION AUTHORIZATION tempDBM0;
    PERFORM ClassDB.dropDBManager('testDBM2');
-   RESET client_min_messages;
 
    --Drop server role and owned objects for fourth DB manager
    PERFORM ClassDB.dropDBManager('testDBM3', TRUE, TRUE, 'drop_c');
 
-   --Drop fifth DB manager
+   --Drop fifth DB manager, who has an additional non-ClassDB schema
    PERFORM ClassDB.dropDBManager('testDBM4');
 
    --Drop multi-role DB manager
-   SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.dropDBManager('testDBMStu0');
-   RESET client_min_messages;
 
+   --Switch back to superuser role before validating test cases
+   RESET SESSION AUTHORIZATION;
+   
+   --Turn all messages back on
+   RESET client_min_messages;
+   
    --Check for correct existence of roles
    IF    NOT ClassDB.isServerRoleDefined('testDBM0')
       OR ClassDB.isServerRoleDefined('testDBM1')
@@ -914,19 +953,19 @@ BEGIN
    END IF;
 
    --Check for ownership of existing schemas
-   IF NOT(ClassDB.getSchemaOwnerName('testDBM0') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testDBM1') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testDBM4') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testSchema') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testDBMStu0') = 'classdb_instructor')
+   IF NOT(ClassDB.getSchemaOwnerName('testDBM0') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testDBM1') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testDBM4') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testSchema') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testDBMStu0') = 'tempdbm0')
    THEN
       RETURN 'FAIL: Code 3';
    END IF;
 
    --Cleanup
-   DROP ROLE testDBM0, testDBM4, testDBMStu0;
-   DROP SCHEMA testDBM0 ,testDBM1, testDBM4, testSchema, testDBMStu0;
-   DELETE FROM ClassDB.RoleBase WHERE RoleName = 'testdbmstu0';
+   DROP OWNED BY tempDBM0;
+   DROP ROLE testDBM0, testDBM4, testDBMStu0, tempDBM0;
+   DELETE FROM ClassDB.RoleBase WHERE RoleName IN ('testdbmstu0', 'tempdbm0');
 
    RETURN 'PASS';
 END;
@@ -939,9 +978,16 @@ BEGIN
    --Create two test students
    PERFORM ClassDB.createStudent('testStu0', 'Test student 0');
    PERFORM ClassDB.createStudent('testStu1', 'Test student 1');
+   
+   --Create DB manager to handle default object disposition
+   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');  
+   SET SESSION AUTHORIZATION tempDBM0;
 
    --Minimal drop
    PERFORM ClassDB.dropAllStudents();
+   
+   --Reset back to superuser role for test case validation
+   RESET SESSION AUTHORIZATION;
 
    --Check for correct existence of roles
    IF    NOT ClassDB.isServerRoleDefined('testStu0')
@@ -958,8 +1004,8 @@ BEGIN
    END IF;
 
    --Check for ownership of existing schemas
-   IF NOT(ClassDB.getSchemaOwnerName('testStu0') = 'classdb_instructor'
-      AND ClassDB.getSchemaOwnerName('testStu1') = 'classdb_instructor')
+   IF NOT(ClassDB.getSchemaOwnerName('testStu0') = 'tempdbm0'
+      AND ClassDB.getSchemaOwnerName('testStu1') = 'tempdbm0')
    THEN
       RETURN 'FAIL: Code 3';
    END IF;
@@ -988,7 +1034,12 @@ BEGIN
    THEN
       RETURN 'FAIL: Code 5';
    END IF;
-
+   
+   --Cleanup
+   DROP OWNED BY tempDBM0;
+   DROP ROLE tempDBM0;
+   DELETE FROM ClassDB.RoleBase WHERE RoleName = 'tempdbm0';
+   
    RETURN 'PASS';
 END;
 $$ LANGUAGE plpgsql;
@@ -1014,4 +1065,4 @@ $$  LANGUAGE plpgsql;
 SELECT pg_temp.prepareClassDBTest();
 
 
-COMMIT;
+ROLLBACK;

--- a/tests/testRoleBaseMgmt.sql
+++ b/tests/testRoleBaseMgmt.sql
@@ -246,31 +246,57 @@ BEGIN
 --------------------------------------------------------------------------------
 
    --test dropping a role while also dropping it from the server
-   --also test object assignment to ClassDB_Instructor
+   --also test object assignment to current user
+   --give role u1 execution permission on dropRole and execute dropRole as u1
+   -- cannot call dropRole as a superuser or any classdb group role
 
    --t1 is a known role
    RAISE INFO '%   isRoleKnown(t1: before dropRole)',
    CASE ClassDB.isRoleKnown('t1') WHEN TRUE THEN 'PASS' ELSE 'FAIL: Code 32' END;
 
-   --drop u1 from record and from the server; assign objects to ClassDB_Instructor
+   --let u1 execute function dropRole
+   GRANT USAGE ON SCHEMA ClassDB TO u1;
+   GRANT EXECUTE ON FUNCTION
+      ClassDB.dropRole(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN, VARCHAR,
+                       ClassDB.IDNameDomain
+                      )
+   TO u1;
+
+   --become u1
+   SET SESSION AUTHORIZATION u1;
+
+   --drop t1 from record and from the server; assign objects to current user (u1)
    PERFORM ClassDB.dropRole('t1', TRUE);
 
+   --go back to being the orginal users
+   RESET SESSION AUTHORIZATION;
+
+   --u1 no longer needs access to function dropRole
+   REVOKE USAGE ON SCHEMA ClassDB FROM u1;
+   REVOKE EXECUTE ON FUNCTION
+      ClassDB.dropRole(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN, VARCHAR,
+                       ClassDB.IDNameDomain
+                      )
+   FROM u1;
+
    --t1 is no longer a known role
-   RAISE INFO '%   isRoleKnown(u1: after dropRole)',
+   RAISE INFO '%   isRoleKnown(t1: after dropRole)',
    CASE ClassDB.isRoleKnown('t1') WHEN TRUE THEN 'FAIL: Code 33' ELSE 'PASS' END;
 
    --t1 is no longer a server role
-   RAISE INFO '%   isServerRoleDefined(u1: after dropRole)',
+   RAISE INFO '%   isServerRoleDefined(t1: after dropRole)',
    CASE ClassDB.isServerRoleDefined('t1') WHEN TRUE THEN 'FAIL: Code 34' ELSE 'PASS' END;
 
-   --t1's schema exists but is owned by classdb_instructor
-   RAISE INFO '%   createRole(s1, s1 name, FALSE)',
+   --t1's schema exists but is owned by role 'u1' (t1's objects assigned to u1)
+   RAISE INFO '%   dropRole(t1, TRUE)',
    CASE EXISTS(SELECT * FROM information_schema.schemata
-               WHERE schema_name = 't1_schema' AND schema_owner = 'classdb_instructor'
+               WHERE schema_name = 't1_schema' AND schema_owner = 'u1'
               )
       WHEN TRUE THEN 'PASS'
       ELSE 'FAIL: Code 35'
    END;
+
+
 
 --------------------------------------------------------------------------------
 
@@ -303,15 +329,8 @@ BEGIN
 
 --------------------------------------------------------------------------------
 
-   --clean up
-
-   --u1 is still a server role, but it does not own any object
-   DROP ROLE u1;
-
-   --t1's schema is still around (owned by ClassDB_Instructor)
-   DROP SCHEMA t1_schema CASCADE;
-
 END
 $$;
 
-COMMIT;
+
+ROLLBACK;


### PR DESCRIPTION
Fixes #191

Commit a6802a7 makes the following changes:
- Change default value of `objectsDisposition` in function `dropRole` to `'assign'` from `'assign_i'` and remove choices of `'assign_i'` and `'assign_m'` for that parameter.
- Prevent a ClassDB group role from becoming the new owner.
- Make `SESSION_USER` the default new owner if no new owner is specified.

The changes turned out to be a bit more involved than I'd thought it would be. Everything appears to work in the limited testing I have done so far, but I need to review the code again tomorrow with fresh eyes and run broader tests. In the meanwhile, let me know if any of you find any issue.

BTW, I believe I need to revise `testRoleBaseMgmt.sql` because one of the test cases there no longer applies.