### PR TITLE
Make logging tests use new drop dispositions and improve user views

### DIFF
--- a/src/db/core/addClassDBRolesViewsCore.sql
+++ b/src/db/core/addClassDBRolesViewsCore.sql
@@ -79,7 +79,8 @@ LEFT OUTER JOIN
   FROM ClassDB.ConnectionActivity
   GROUP BY UserName
 ) AS C ON C.UserName = RoleName
-WHERE NOT IsTeam;
+WHERE NOT IsTeam
+ORDER BY UserName;
 
 
 ALTER VIEW ClassDB.User OWNER TO ClassDB;

--- a/src/db/reco/addFrequentViewsReco.sql
+++ b/src/db/reco/addFrequentViewsReco.sql
@@ -191,7 +191,7 @@ CREATE OR REPLACE VIEW ClassDB.StudentActivitySummaryAnon AS
 (
    SELECT DDLCount, LastDDLOperation, LastDDLObject, LastDDLActivityAt,
           ConnectionCount, LastConnectionAt
-   FROM   ClassDB.getStudentActivitySummary()
+   FROM   ClassDB.getStudentActivitySummaryAnon()
 );
 
 ALTER VIEW ClassDB.StudentActivitySummaryAnon OWNER TO ClassDB;
@@ -363,7 +363,8 @@ $$
    FROM ClassDB.getUserDDLActivity(COALESCE($1, '%'))
    UNION ALL
    SELECT UserName, AcceptedAt, 'Connection', NULL, NULL
-   FROM ClassDB.getUserConnectionActivity(COALESCE($1, '%'));
+   FROM ClassDB.getUserConnectionActivity(COALESCE($1, '%'))
+   ORDER BY UserName;
 $$ LANGUAGE sql
    STABLE
    SECURITY DEFINER;

--- a/tests/testAddConnectionActivityLogging.psql
+++ b/tests/testAddConnectionActivityLogging.psql
@@ -117,15 +117,10 @@ BEGIN
    END IF;
 
    --Drop users & related objects
-   PERFORM ClassDB.dropStudent('conStudent01', true);
-   PERFORM ClassDB.dropStudent('conStudent02', true);
-   PERFORM ClassDB.dropInstructor('conInstructor01', true);
-   PERFORM ClassDB.dropDBManager('conDBManager01', true);
-
-   DROP SCHEMA conStudent01 CASCADE;
-   DROP SCHEMA conStudent02 CASCADE;
-   DROP SCHEMA conInstructor01 CASCADE;
-   DROP SCHEMA conDBManager01 CASCADE;
+   PERFORM ClassDB.dropStudent('conStudent01', true, true, 'drop_c');
+   PERFORM ClassDB.dropStudent('conStudent02', true, true, 'drop_c');
+   PERFORM ClassDB.dropInstructor('conInstructor01', true, true, 'drop_c');
+   PERFORM ClassDB.dropDBManager('conDBManager01', true, true, 'drop_c');
 
    --DROP OWNED BY conNonClassDB;
    --DROP USER conNonClassDB CASCADE;

--- a/tests/testAddConnectionActivityLoggingCleanup.sql
+++ b/tests/testAddConnectionActivityLoggingCleanup.sql
@@ -32,15 +32,10 @@ BEGIN
 
 
    --Remove orpahned users
-   PERFORM ClassDB.dropStudent('conStudent01', true);
-   PERFORM ClassDB.dropStudent('conStudent02', true);
-   PERFORM ClassDB.dropInstructor('conInstructor01', true);
-   PERFORM ClassDB.dropDBManager('conDBManager01', true);
-
-   DROP SCHEMA conStudent01 CASCADE;
-   DROP SCHEMA conStudent02 CASCADE;
-   DROP SCHEMA conInstructor01 CASCADE;
-   DROP SCHEMA conDBManager01 CASCADE;
+   PERFORM ClassDB.dropStudent('conStudent01', true, true, 'drop_c');
+   PERFORM ClassDB.dropStudent('conStudent02', true, true, 'drop_c');
+   PERFORM ClassDB.dropInstructor('conInstructor01', true, true, 'drop_c');
+   PERFORM ClassDB.dropDBManager('conDBManager01', true, true, 'drop_c');
 
    --DROP OWNED BY conNonClassDB;
    --DROP USER conNonClassDB;

--- a/tests/testAddDDLActivityLogging.sql
+++ b/tests/testAddDDLActivityLogging.sql
@@ -202,22 +202,6 @@ BEGIN
 
    RESET SESSION AUTHORIZATION;
 
-
-   --Drop users & related objects
-   PERFORM ClassDB.dropStudent('ddlStudent01', true);
-   PERFORM ClassDB.dropStudent('ddlStudent02', true);
-   PERFORM ClassDB.dropInstructor('ddlInstructor01', true);
-   PERFORM ClassDB.dropDBManager('ddlDBManager01', true);
-
-   DROP SCHEMA ddlStudent01 CASCADE;
-   DROP SCHEMA ddlStudent02 CASCADE;
-   DROP SCHEMA ddlInstructor01 CASCADE;
-   DROP SCHEMA ddlDBManager01 CASCADE;
-
-   --Drop non-ClassDB user
-   DROP SCHEMA ddlNonClassDBUser CASCADE;
-   DROP USER ddlNonClassDBUser;
-
    RAISE NOTICE 'Success!';
    RAISE NOTICE 'Displaying final contents of ClassDB.DDLActivity:';
 END;
@@ -226,4 +210,4 @@ $$;
 SELECT *
 FROM ClassDB.DDLActivity;
 
-COMMIT;
+ROLLBACK;


### PR DESCRIPTION
This is a collection of small fixes/improvements to the logging tests scripts and user views. I intended for this to be two separate PRs, but I accidentally merged all the changes into one commit.

- The logging tests no longer fail due to the new drop dispositions. The new [removing users](https://github.com/DASSL/ClassDB/wiki/Removing-Users) page helped a lot with making this change easy (@afig)
- The `ClassDB.StudentActivitySummaryAnon` view now calls the correct underlying function
- `ClassDB.getUserAcitivity()` orders activity records by username, so all views/functions that return individual activity records are now ordered by username.

With these changes, all tests pass a new ClassDB instance setup using the new quick-start guide 🎉 