### PR TITLE
Make CreateXYZ functions Safe

### DIFF
--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -133,15 +133,6 @@ CREATE OR REPLACE FUNCTION
    RETURNS VOID AS
 $$
 BEGIN
-   --If password was supplied give warning
-   IF ($7 IS NOT NULL) THEN
-      RAISE WARNING 'For security reasons, parameter "initialPwd" is ignored '
-                    'and user password has been set using the default password '
-                    'policy described in the API documentation.'
-         USING HINT = 'Parameter "initialPwd" will be dropped in the next API'
-                      'release. Please update your code.';
-   END IF;
-
    --record ClassDB role
    PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6);
 
@@ -161,6 +152,14 @@ BEGIN
                   ' ClassDB_Instructor', $3);
    EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                   ' GRANT SELECT ON TABLES TO ClassDB_Instructor', $1, $3);
+
+   --If password was supplied give warning
+   IF ($7 IS NOT NULL) THEN
+   RAISE WARNING 'parameter "initialPwd" ignored and password set to default value'
+         USING DETAIL = 'Parameter "initialPwd" is deprecated and will be '
+         'dropped in the next release. Please update your code.',
+         HINT = 'Consult the API documentation for details on the password policy.';
+   END IF;
 END;
 $$ LANGUAGE plpgsql
    SECURITY DEFINER;
@@ -313,15 +312,6 @@ CREATE OR REPLACE FUNCTION
    RETURNS VOID AS
 $$
 BEGIN
-   --If password was supplied give warning
-   IF ($7 IS NOT NULL) THEN
-      RAISE WARNING 'For security reasons, parameter "initialPwd" is ignored '
-                    'and user password has been set using the default password '
-                    'policy described in the API documentation.'
-         USING HINT = 'Parameter "initialPwd" will be dropped in the next API'
-                      'release. Please update your code.';
-   END IF;
-
    --record ClassDB role
    PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6);
 
@@ -331,6 +321,14 @@ BEGIN
    --set privileges on future tables the instructor creates in 'public' schema
    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA public GRANT'
                || ' SELECT ON TABLES TO PUBLIC', $1);
+
+   --If password was supplied give warning
+   IF ($7 IS NOT NULL) THEN
+   RAISE WARNING 'parameter "initialPwd" ignored and password set to default value'
+         USING DETAIL = 'Parameter "initialPwd" is deprecated and will be '
+         'dropped in the next release. Please update your code.',
+         HINT = 'Consult the API documentation for details on the password policy.';
+   END IF;
 END;
 $$ LANGUAGE plpgsql
    SECURITY DEFINER;
@@ -447,20 +445,19 @@ CREATE OR REPLACE FUNCTION
    RETURNS VOID AS
 $$
 BEGIN
-   --If password was supplied give warning
-   IF ($7 IS NOT NULL) THEN
-      RAISE WARNING 'For security reasons, parameter "initialPwd" is ignored '
-                    'and user password has been set using the default password '
-                    'policy described in the API documentation.'
-         USING HINT = 'Parameter "initialPwd" will be dropped in the next API'
-                      'release. Please update your code.';
-   END IF;
-
    --record ClassDB role
    PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6);
 
    --grant server-level DB manager group role to new DB manager
    PERFORM ClassDB.grantRole('ClassDB_DBManager', $1);
+
+   --If password was supplied give warning
+   IF ($7 IS NOT NULL) THEN
+   RAISE WARNING 'parameter "initialPwd" ignored and password set to default value'
+         USING DETAIL = 'Parameter "initialPwd" is deprecated and will be '
+         'dropped in the next release. Please update your code.',
+         HINT = 'Consult the API documentation for details on the password policy.';
+   END IF;
 END;
 $$ LANGUAGE plpgsql
    SECURITY DEFINER;

--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -135,12 +135,15 @@ $$
 BEGIN
    --If password was supplied give warning
    IF ($7 IS NOT NULL) THEN
-      RAISE WARNING 'initialPwd is no longer a valid parameter, password will be
-          be set to the default password.';
+      RAISE WARNING 'For security reasons, parameter "initialPwd" is ignored '
+                    'and user password has been set using the default password '
+                    'policy described in the API documentation.'
+         USING HINT = 'Parameter "initialPwd" will be dropped in the next API'
+                      'release. Please update your code.';
    END IF;
 
    --record ClassDB role
-   PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6, $1);
+   PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6);
 
    --get name of role's schema (possibly not the original value of schemaName)
    $3 = ClassDB.getSchemaName($1);
@@ -312,12 +315,15 @@ $$
 BEGIN
    --If password was supplied give warning
    IF ($7 IS NOT NULL) THEN
-       RAISE WARNING 'initialPwd is no longer a valid parameter, password will be
-           be set to the default password.';
+      RAISE WARNING 'For security reasons, parameter "initialPwd" is ignored '
+                    'and user password has been set using the default password '
+                    'policy described in the API documentation.'
+         USING HINT = 'Parameter "initialPwd" will be dropped in the next API'
+                      'release. Please update your code.';
    END IF;
 
    --record ClassDB role
-   PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6, $1);
+   PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6);
 
    --grant server-level instructor group role to new instructor
    PERFORM ClassDB.grantRole('ClassDB_Instructor', $1);
@@ -443,12 +449,15 @@ $$
 BEGIN
    --If password was supplied give warning
    IF ($7 IS NOT NULL) THEN
-       RAISE WARNING 'initialPwd is no longer a valid parameter, password will be
-           be set to the default password.';
+      RAISE WARNING 'For security reasons, parameter "initialPwd" is ignored '
+                    'and user password has been set using the default password '
+                    'policy described in the API documentation.'
+         USING HINT = 'Parameter "initialPwd" will be dropped in the next API'
+                      'release. Please update your code.';
    END IF;
 
    --record ClassDB role
-   PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6, $1);
+   PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6);
 
    --grant server-level DB manager group role to new DB manager
    PERFORM ClassDB.grantRole('ClassDB_DBManager', $1);

--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -133,8 +133,14 @@ CREATE OR REPLACE FUNCTION
    RETURNS VOID AS
 $$
 BEGIN
+   --If password was supplied give warning
+   IF ($7 IS NOT NULL) THEN
+      RAISE WARNING 'initialPwd is no longer a valid parameter, password will be
+          be set to the default password.';
+   END IF;
+
    --record ClassDB role
-   PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6, $7);
+   PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6, $1);
 
    --get name of role's schema (possibly not the original value of schemaName)
    $3 = ClassDB.getSchemaName($1);
@@ -304,8 +310,14 @@ CREATE OR REPLACE FUNCTION
    RETURNS VOID AS
 $$
 BEGIN
+   --If password was supplied give warning
+   IF ($7 IS NOT NULL) THEN
+       RAISE WARNING 'initialPwd is no longer a valid parameter, password will be
+           be set to the default password.';
+   END IF;
+
    --record ClassDB role
-   PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6, $7);
+   PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6, $1);
 
    --grant server-level instructor group role to new instructor
    PERFORM ClassDB.grantRole('ClassDB_Instructor', $1);
@@ -429,8 +441,14 @@ CREATE OR REPLACE FUNCTION
    RETURNS VOID AS
 $$
 BEGIN
+   --If password was supplied give warning
+   IF ($7 IS NOT NULL) THEN
+       RAISE WARNING 'initialPwd is no longer a valid parameter, password will be
+           be set to the default password.';
+   END IF;
+
    --record ClassDB role
-   PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6, $7);
+   PERFORM ClassDB.createRole($1, $2, FALSE, $3, $4, $5, $6, $1);
 
    --grant server-level DB manager group role to new DB manager
    PERFORM ClassDB.grantRole('ClassDB_DBManager', $1);

--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -158,7 +158,7 @@ BEGIN
    RAISE WARNING 'parameter "initialPwd" ignored and password set to default value'
          USING DETAIL = 'Parameter "initialPwd" is deprecated and will be '
          'dropped in the next release. Please update your code.',
-         HINT = 'Consult the API documentation for details on the password policy.';
+         HINT = 'Consult ClassDB documentation for details on password policy.';
    END IF;
 END;
 $$ LANGUAGE plpgsql
@@ -327,7 +327,7 @@ BEGIN
    RAISE WARNING 'parameter "initialPwd" ignored and password set to default value'
          USING DETAIL = 'Parameter "initialPwd" is deprecated and will be '
          'dropped in the next release. Please update your code.',
-         HINT = 'Consult the API documentation for details on the password policy.';
+         HINT = 'Consult ClassDB documentation for details on password policy.';
    END IF;
 END;
 $$ LANGUAGE plpgsql
@@ -456,7 +456,7 @@ BEGIN
    RAISE WARNING 'parameter "initialPwd" ignored and password set to default value'
          USING DETAIL = 'Parameter "initialPwd" is deprecated and will be '
          'dropped in the next release. Please update your code.',
-         HINT = 'Consult the API documentation for details on the password policy.';
+         HINT = 'Consult ClassDB documentation for details on password policy.';
    END IF;
 END;
 $$ LANGUAGE plpgsql

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -108,7 +108,7 @@ BEGIN
    PERFORM ClassDB.createStudent('testStu0', 'Test student 0');
    --Extra info given: Pwd and schema set to username, extrainfo should be stored
    PERFORM ClassDB.createStudent('testStu1', 'Test student 1', NULL, '101');
-   --initialPassword given: Password should be set to 'testpass'
+   --initialPassword given: Password should be set to 'testStu2'
    PERFORM ClassDB.createStudent('testStu2', 'Test student 2', NULL, '102',
                                  FALSE, FALSE, 'testpass');
    --initialPassword with no extra info
@@ -154,9 +154,9 @@ BEGIN
    --Test password (hashes) set to students
    IF NOT(pg_temp.checkEncryptedPwd('testStu0', 'teststu0')
       AND pg_temp.checkEncryptedPwd('testStu1', 'teststu1')
-      AND pg_temp.checkEncryptedPwd('testStu2', 'testpass')
-      AND pg_temp.checkEncryptedPwd('testStu3', 'testpass2')
-      AND pg_temp.checkEncryptedPwd('testStuDBM0', 'testpass3')
+      AND pg_temp.checkEncryptedPwd('testStu2', 'testStu2')
+      AND pg_temp.checkEncryptedPwd('testStu3', 'testStu3')
+      AND pg_temp.checkEncryptedPwd('testStuDBM0', 'testStuDBM0')
       AND pg_temp.checkEncryptedPwd('testStu4', 'teststu4'))
    THEN
       RETURN 'FAIL: Code 3';
@@ -234,7 +234,7 @@ BEGIN
    PERFORM ClassDB.createInstructor('testIns0', 'Test instructor 0');
    --Extra info given: Pwd and schema set to username, extrainfo should be stored
    PERFORM ClassDB.createInstructor('testIns1', 'Test instructor 1', NULL, '101');
-   --initialPassword given: Password should be set to 'testpass'
+   --initialPassword given: Password should be set to 'testIns2'
    PERFORM ClassDB.createInstructor('testIns2', 'Test instructor 2', NULL, '102',
                                  FALSE, FALSE, 'testpass');
    --initialPassword with no extra info
@@ -280,9 +280,9 @@ BEGIN
    --Test password (hashes) set to instructors
    IF NOT(pg_temp.checkEncryptedPwd('testIns0', 'testins0')
       AND pg_temp.checkEncryptedPwd('testIns1', 'testins1')
-      AND pg_temp.checkEncryptedPwd('testIns2', 'testpass')
-      AND pg_temp.checkEncryptedPwd('testIns3', 'testpass2')
-      AND pg_temp.checkEncryptedPwd('testInsDBM0', 'testpass3')
+      AND pg_temp.checkEncryptedPwd('testIns2', 'testIns2')
+      AND pg_temp.checkEncryptedPwd('testIns3', 'testIns3')
+      AND pg_temp.checkEncryptedPwd('testInsDBM0', 'testInsDBM0')
       AND pg_temp.checkEncryptedPwd('testIns4', 'testins4'))
    THEN
       RETURN 'FAIL: Code 3';
@@ -358,7 +358,7 @@ BEGIN
    PERFORM ClassDB.createDBManager('testDBM0', 'Test DB manager 0');
    --Extra info given: Pwd and schema set to username, extrainfo should be stored
    PERFORM ClassDB.createDBManager('testDBM1', 'Test DB manager 1', NULL, '101');
-   --initialPassword given: Password should be set to 'testpass'
+   --initialPassword given: Password should be set to 'testDBM2'
    PERFORM ClassDB.createDBManager('testDBM2', 'Test DB manager 2', NULL, '102',
                                  FALSE, FALSE, 'testpass');
    --initialPassword with no extra info
@@ -404,9 +404,9 @@ BEGIN
    --Test password (hashes) set to DB managers
    IF NOT(pg_temp.checkEncryptedPwd('testDBM0', 'testdbm0')
       AND pg_temp.checkEncryptedPwd('testDBM1', 'testdbm1')
-      AND pg_temp.checkEncryptedPwd('testDBM2', 'testpass')
-      AND pg_temp.checkEncryptedPwd('testDBM3', 'testpass2')
-      AND pg_temp.checkEncryptedPwd('testDBMStu0', 'testpass3')
+      AND pg_temp.checkEncryptedPwd('testDBM2', 'testDBM2')
+      AND pg_temp.checkEncryptedPwd('testDBM3', 'testDBM3')
+      AND pg_temp.checkEncryptedPwd('testDBMStu0', 'testDBMStu0')
       AND pg_temp.checkEncryptedPwd('testDBM4', 'testdbm4'))
    THEN
       RETURN 'FAIL: Code 3';
@@ -689,11 +689,11 @@ BEGIN
    SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.createDBManager('testStuDBM0', 'Test student/DB manager 0');
    RESET client_min_messages;
-   
+
    --Create DB manager to handle default object disposition
-   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');  
+   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');
    SET SESSION AUTHORIZATION tempDBM0;
-   
+
    --Suppress NOTICEs about ownership reassignment
    SET SESSION client_min_messages TO WARNING;
 
@@ -723,10 +723,10 @@ BEGIN
 
    --Switch back to superuser role before validating test cases
    RESET SESSION AUTHORIZATION;
-   
+
    --Turn all messages back on
    RESET client_min_messages;
-   
+
    --Check for correct existence of roles
    IF    NOT ClassDB.isServerRoleDefined('testStu0')
       OR ClassDB.isServerRoleDefined('testStu1')
@@ -790,11 +790,11 @@ BEGIN
    SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.createDBManager('testInsDBM0', 'Test instructor/DB manager 0');
    RESET client_min_messages;
-   
+
    --Create DB manager to handle default object disposition
-   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');  
+   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');
    SET SESSION AUTHORIZATION tempDBM0;
-   
+
    --Suppress NOTICEs about ownership reassignment
    SET SESSION client_min_messages TO WARNING;
 
@@ -824,10 +824,10 @@ BEGIN
 
    --Switch back to superuser role before validating test cases
    RESET SESSION AUTHORIZATION;
-   
+
    --Turn all messages back on
    RESET client_min_messages;
-   
+
    --Check for correct existence of roles
    IF    NOT ClassDB.isServerRoleDefined('testIns0')
       OR ClassDB.isServerRoleDefined('testIns1')
@@ -891,11 +891,11 @@ BEGIN
    SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.createStudent('testDBMStu0', 'Test DB manager/Student 0');
    RESET client_min_messages;
-   
+
    --Create DB manager to handle default object disposition
-   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');  
+   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');
    SET SESSION AUTHORIZATION tempDBM0;
-   
+
    --Suppress NOTICEs about ownership reassignment
    SET SESSION client_min_messages TO WARNING;
 
@@ -925,10 +925,10 @@ BEGIN
 
    --Switch back to superuser role before validating test cases
    RESET SESSION AUTHORIZATION;
-   
+
    --Turn all messages back on
    RESET client_min_messages;
-   
+
    --Check for correct existence of roles
    IF    NOT ClassDB.isServerRoleDefined('testDBM0')
       OR ClassDB.isServerRoleDefined('testDBM1')
@@ -978,14 +978,14 @@ BEGIN
    --Create two test students
    PERFORM ClassDB.createStudent('testStu0', 'Test student 0');
    PERFORM ClassDB.createStudent('testStu1', 'Test student 1');
-   
+
    --Create DB manager to handle default object disposition
-   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');  
+   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');
    SET SESSION AUTHORIZATION tempDBM0;
 
    --Minimal drop
    PERFORM ClassDB.dropAllStudents();
-   
+
    --Reset back to superuser role for test case validation
    RESET SESSION AUTHORIZATION;
 
@@ -1034,12 +1034,12 @@ BEGIN
    THEN
       RETURN 'FAIL: Code 5';
    END IF;
-   
+
    --Cleanup
    DROP OWNED BY tempDBM0;
    DROP ROLE tempDBM0;
    DELETE FROM ClassDB.RoleBase WHERE RoleName = 'tempdbm0';
-   
+
    RETURN 'PASS';
 END;
 $$ LANGUAGE plpgsql;

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -999,8 +999,8 @@ SELECT pg_temp.prepareClassDBTest();
 CREATE OR REPLACE FUNCTION pg_temp.rejectCustomPasswordTest() RETURNS TEXT AS
 $$
 BEGIN
-   RAISE NOTICE 'The following test should RAISE three warnings regarding' 
-                'ignoring of an initial password';
+   RAISE NOTICE 'The following test should RAISE three warnings regarding'
+                ' ignoring of an initial password';
    --Test password creation for student
    PERFORM ClassDB.createStudent('testStuCustomPwd', 'TestStu', NULL, NULL,
                                    FALSE, FALSE, 'TestPassStudent');

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -1000,24 +1000,24 @@ CREATE OR REPLACE FUNCTION pg_temp.rejectCustomPasswordTest() RETURNS TEXT AS
 $$
 BEGIN
    --Test password creation for student
-   PERFORM ClassDB.createStudent('testStuCustomPwd', 'Wrong Name', NULL, NULL,
+   PERFORM ClassDB.createStudent('testStuCustomPwd', 'TestStu', NULL, NULL,
                                    FALSE, FALSE, 'TestPassStudent');
    --Test password creation for instructor
-   PERFORM ClassDB.createInstructor('testInsCustomPwd', 'Wrong Name', NULL, NULL,
+   PERFORM ClassDB.createInstructor('testInsCustomPwd', 'TestIns', NULL, NULL,
                                    FALSE, FALSE, 'TestPassInstuctor');
    --Test password creation for database manager
-   PERFORM ClassDB.createDBManager('testDBMCustomPwd', 'Wrong Name', NULL, NULL,
+   PERFORM ClassDB.createDBManager('testDBMCustomPwd', 'TestDBM', NULL, NULL,
                                    FALSE, FALSE, 'TestPassDMB');
 
    --Test password for all test roles
-   IF NOT(pg_temp.checkEncryptedPwd('testStuCustomPwd', ClassDB.foldPgID('testStuCustomPwd'))
+   IF (pg_temp.checkEncryptedPwd('testStuCustomPwd', ClassDB.foldPgID('testStuCustomPwd'))
       AND pg_temp.checkEncryptedPwd('testInsCustomPwd', ClassDB.foldPgID('testInsCustomPwd'))
       AND pg_temp.checkEncryptedPwd('testDBMCustomPwd', ClassDB.foldPgID('testDBMCustomPwd')))
    THEN
+      RETURN 'PASS';
+   ELSE
       RETURN 'FAIL: Code 3';
    END IF;
-
-   RETURN 'PASS';
 END;
 $$ LANGUAGE plpgsql;
 

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -1021,7 +1021,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DO language plpgsql $$
+DO
+$$
 BEGIN
   RAISE INFO '%   rejectCustomPasswordTest()', pg_temp.rejectCustomPasswordTest();
 END

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -1,6 +1,6 @@
 --testClassDBRolesMgmt.sql - ClassDB
 
---Andrew Figueroa, Steven Rollo, Sean Murthy
+--Andrew Figueroa, Steven Rollo, Sean Murthy, Kevin Kelly
 --Data Science & Systems Lab (DASSL)
 --https://dassl.github.io/
 
@@ -990,49 +990,41 @@ $$  LANGUAGE plpgsql;
 SELECT pg_temp.prepareClassDBTest();
 
 --Section 2
--- This section tests each of the createXYZ functions to make sure that if
--- supplied with a password that the function raises a warning and sets the
--- password to the default
+-- This section tests each of the createXYZ functions to ensure that if the function
+-- is supplied with a initialPwd that the function rejects the password and sets
+-- the password to the default. This section will be removed when parameter
+-- initialPwd is removed from createXYZ functions.
 
-CREATE OR REPLACE FUNCTION pg_temp.defaultPasswordTest() RETURNS TEXT AS
+
+CREATE OR REPLACE FUNCTION pg_temp.rejectCustomPasswordTest() RETURNS TEXT AS
 $$
 BEGIN
-    --Test password creation for instructor
-    PERFORM ClassDB.createStudent('testStu', 'Wrong Name', NULL, NULL,
-                                    FALSE, FALSE, 'TestPass1');
+   --Test password creation for student
+   PERFORM ClassDB.createStudent('testStuCustomPwd', 'Wrong Name', NULL, NULL,
+                                   FALSE, FALSE, 'TestPassStudent');
    --Test password creation for instructor
-   PERFORM ClassDB.createInstructor('testIns', 'Wrong Name', NULL, NULL,
-                                   FALSE, FALSE, 'TestPass2');
-   --Test password creation for instructor
-   PERFORM ClassDB.createDBManager('testDBM', 'Wrong Name', NULL, NULL,
-                                   FALSE, FALSE, 'TestPass3');
+   PERFORM ClassDB.createInstructor('testInsCustomPwd', 'Wrong Name', NULL, NULL,
+                                   FALSE, FALSE, 'TestPassInstuctor');
+   --Test password creation for database manager
+   PERFORM ClassDB.createDBManager('testDBMCustomPwd', 'Wrong Name', NULL, NULL,
+                                   FALSE, FALSE, 'TestPassDMB');
 
-   --Test password (hashes) set to DB managers
-   IF NOT(pg_temp.checkEncryptedPwd('testStu', ClassDB.foldPgID('testStu'))
-      AND pg_temp.checkEncryptedPwd('testIns', ClassDB.foldPgID('testIns'))
-      AND pg_temp.checkEncryptedPwd('testDBM', ClassDB.foldPgID('testDBM')))
+   --Test password for all test roles
+   IF NOT(pg_temp.checkEncryptedPwd('testStuCustomPwd', ClassDB.foldPgID('testStuCustomPwd'))
+      AND pg_temp.checkEncryptedPwd('testInsCustomPwd', ClassDB.foldPgID('testInsCustomPwd'))
+      AND pg_temp.checkEncryptedPwd('testDBMCustomPwd', ClassDB.foldPgID('testDBMCustomPwd')))
    THEN
       RETURN 'FAIL: Code 3';
    END IF;
-
-   --Cleanup
-   DROP OWNED BY testStu;
-   DROP ROLE testStu;
-   DELETE FROM ClassDB.RoleBase WHERE roleName = 'teststu';
-
-   DROP OWNED BY testIns;
-   DROP ROLE testIns;
-   DELETE FROM ClassDB.RoleBase WHERE roleName = 'testins';
-
-   DROP OWNED BY testDBM;
-   DROP ROLE testDBM;
-   DELETE FROM ClassDB.RoleBase WHERE roleName = 'testdbm';
 
    RETURN 'PASS';
 END;
 $$ LANGUAGE plpgsql;
 
-SELECT pg_temp.defaultPasswordTest();
-
+DO language plpgsql $$
+BEGIN
+  RAISE INFO '%   rejectCustomPasswordTest()', pg_temp.rejectCustomPasswordTest();
+END
+$$;
 
 ROLLBACK;

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -219,7 +219,7 @@ BEGIN
 
    --Updating with different schema: Create instructor, create schema, then update
    PERFORM ClassDB.createInstructor('testIns2', 'Wrong Name');
-   CREATE SCHEMA newTestIns2 AUTHORIZATION testIns4;
+   CREATE SCHEMA newTestIns2 AUTHORIZATION testIns2;
    SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.createInstructor('testIns2', 'Test instructor 2');
    RESET client_min_messages;
@@ -318,7 +318,7 @@ BEGIN
 
    --Updating with different schema: Create DB manager, create schema, then update
    PERFORM ClassDB.createDBManager('testDBM2', 'Wrong Name');
-   CREATE SCHEMA newTestDBM4 AUTHORIZATION testDBM4;
+   CREATE SCHEMA newTestDBM2 AUTHORIZATION testDBM2;
    SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.createDBManager('testDBM2', 'Test DB manager 2');
    RESET client_min_messages;
@@ -603,9 +603,9 @@ BEGIN
    PERFORM ClassDB.createStudent('testStu2', 'Test student 2');
    PERFORM ClassDB.createStudent('testStu3', 'Test student 3');
 
-   --ExtraInfo and initialPwd provided, then create schema owned by student
+   --ExtraInfo provided, then create schema owned by student
    PERFORM ClassDB.createStudent('testStu4', 'Test student 4', NULL, '100',
-                                 FALSE, FALSE, 'testpass');
+                                 FALSE, FALSE);
    CREATE SCHEMA testSchema AUTHORIZATION testStu1;
 
    --Multi-role user

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -999,6 +999,8 @@ SELECT pg_temp.prepareClassDBTest();
 CREATE OR REPLACE FUNCTION pg_temp.rejectCustomPasswordTest() RETURNS TEXT AS
 $$
 BEGIN
+   RAISE NOTICE 'The following test should RAISE three warnings regarding' 
+                'ignoring of an initial password';
    --Test password creation for student
    PERFORM ClassDB.createStudent('testStuCustomPwd', 'TestStu', NULL, NULL,
                                    FALSE, FALSE, 'TestPassStudent');


### PR DESCRIPTION
This pull request is for issue #201 and the CreateXYZ functions were changed to incorporate those changes suggested by @smurthys in that issue thread. 

This is not ready to be approved but I wanted to get opinions on how to handle the changed test script for the new CreateXYZ functions. All I did was change the test script `testClassDBRolesMgmt.sql` so that the tests on the passwords were testing on the initial password. However, this should raise 3 warnings for each test for a total of 9 warnings. It may be useful to see that a warning pops up to see that the new addition is working correctly but I am not sure it is worth doing 9 times. 

Maybe we should change it so each test function incorrectly supplies a password once. Also suppressing the warning might be a good idea since it will be testing the password to make sure it was set to default later. 