### PR TITLE
Define server team role

### DIFF
--- a/src/db/core/addHelpersCore.sql
+++ b/src/db/core/addHelpersCore.sql
@@ -213,8 +213,7 @@ $$
          SELECT * FROM pg_catalog.pg_roles
          WHERE pg_catalog.pg_has_role(ClassDB.foldPgID($1), oid, 'member')
                AND
-               rolname IN
-               ('classdb_instructor', 'classdb_student', 'classdb_dbmanager')
+               ClassDB.isClassDBRoleName(rolname::ClassDB.IDNameDomain)
       );
 $$ LANGUAGE sql
    STABLE

--- a/src/db/core/addHelpersCore.sql
+++ b/src/db/core/addHelpersCore.sql
@@ -155,7 +155,8 @@ CREATE OR REPLACE FUNCTION
    RETURNS BOOLEAN AS
 $$
    SELECT ClassDB.foldPgID($1)
-          IN ('classdb_instructor', 'classdb_student', 'classdb_dbmanager');
+          IN ('classdb_instructor', 'classdb_student',
+              'classdb_dbmanager', 'classdb_team');
 $$ LANGUAGE sql
    IMMUTABLE
    RETURNS NULL ON NULL INPUT;

--- a/src/db/core/addHelpersCore.sql
+++ b/src/db/core/addHelpersCore.sql
@@ -149,7 +149,7 @@ ALTER FUNCTION ClassDB.getSchemaOwnerName(ClassDB.IDNameDomain) OWNER TO ClassDB
 
 --Define a function to test if a role name is a ClassDB role name
 -- tests if the name supplied is one of the following strings:
---  'classdb_student', 'classdb_instructor', 'classdb_manager'
+--  'classdb_student', 'classdb_instructor', 'classdb_manager', 'classdb_team'
 CREATE OR REPLACE FUNCTION
    ClassDB.isClassDBRoleName(roleName ClassDB.IDNameDomain)
    RETURNS BOOLEAN AS

--- a/src/db/core/initializeDBCore.sql
+++ b/src/db/core/initializeDBCore.sql
@@ -24,6 +24,9 @@
 
 START TRANSACTION;
 
+--Suppress NOTICE messages for this script: won't apply to functions created here
+-- hides unimportant but possibly confusing msgs generated as the script executes
+SET LOCAL client_min_messages TO WARNING;
 
 --Make sure the current user has sufficient privilege to run this script
 -- privilege required: superuser
@@ -50,11 +53,11 @@ BEGIN
    SELECT COUNT(*)
    FROM pg_catalog.pg_roles
    WHERE rolname IN ('classdb', 'classdb_instructor',
-                     'classdb_dbmanager', 'classdb_student'
+                     'classdb_dbmanager', 'classdb_student', 'classdb_team'
                     )
    INTO classDBRoleCount;
 
-   IF classDBRoleCount <> 4 THEN
+   IF classDBRoleCount <> 5 THEN
       RAISE EXCEPTION
          'Missing roles: one or more expected of the expected ClassDB roles '
          'are undefined';

--- a/src/server/core/initalizeServerCore.sql
+++ b/src/server/core/initalizeServerCore.sql
@@ -71,8 +71,10 @@ BEGIN
    PERFORM pg_temp.createGroupRole('classdb_student');
    PERFORM pg_temp.createGroupRole('classdb_instructor');
    PERFORM pg_temp.createGroupRole('classdb_dbmanager');
+   PERFORM pg_temp.createGroupRole('classdb_team');
 
-   GRANT ClassDB_Student, ClassDB_Instructor, ClassDB_DBManager TO ClassDB;
+   GRANT ClassDB_Student, ClassDB_Instructor, ClassDB_DBManager, ClassDB_Team
+   TO ClassDB;
 END
 $$;
 

--- a/src/server/removeAllFromServer.sql
+++ b/src/server/removeAllFromServer.sql
@@ -50,6 +50,7 @@ SET LOCAL client_min_messages TO WARNING;
 DROP ROLE IF EXISTS ClassDB_Instructor;
 DROP ROLE IF EXISTS ClassDB_DBManager;
 DROP ROLE IF EXISTS ClassDB_Student;
+DROP ROLE IF EXISTS ClassDB_Team;
 DROP ROLE IF EXISTS ClassDB;
 
 RESET client_min_messages;


### PR DESCRIPTION
The commits in this PR add a new server role `ClassDB_Team` in preparation for team support. User and ClassDB role management need the server role to support teams. (Those changes are and should be subject of another PR).