### PR TITLE
Add team management

### DIFF
--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -645,5 +645,36 @@ GRANT EXECUTE ON FUNCTION
    TO ClassDB_Instructor, ClassDB_DBManager;
 
 
+--Define function to drop all known teams
+CREATE OR REPLACE FUNCTION
+   ClassDB.dropAllTeams(dropFromServer BOOLEAN DEFAULT FALSE,
+                        okIfRemainsClassDBRoleMember BOOLEAN DEFAULT TRUE,
+                        objectsDisposition VARCHAR DEFAULT 'assign',
+                        newObjectsOwnerName ClassDB.IDNameDomain DEFAULT NULL)
+   RETURNS VOID AS
+$$
+BEGIN
+   PERFORM ClassDB.dropTeam(R.RoleName, $1, $2, $3, $4)
+   FROM ClassDB.RoleBase R
+   WHERE ClassDB.isTeam(RoleName);
+END;
+$$ LANGUAGE plpgsql
+   SECURITY DEFINER;
+
+
+--Change function ownership and set permissions
+ALTER FUNCTION
+   ClassDB.dropAllTeams(BOOLEAN, BOOLEAN, VARCHAR,
+                       ClassDB.IDNameDomain) OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION
+   ClassDB.dropAllTeams(BOOLEAN, BOOLEAN, VARCHAR,
+                        ClassDB.IDNameDomain) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION
+   ClassDB.dropAllTeams(BOOLEAN, BOOLEAN, VARCHAR,
+                        ClassDB.IDNameDomain)
+   TO ClassDB_Instructor, ClassDB_DBManager;
+
 
 COMMIT;

--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -598,12 +598,52 @@ $$ LANGUAGE plpgsql
    SECURITY DEFINER;
 
 
+--Change function ownership and set permissions
 ALTER FUNCTION ClassDB.revokeTeam(ClassDB.IDNameDomain) OWNER TO ClassDB;
 
 REVOKE ALL ON FUNCTION ClassDB.revokeTeam(ClassDB.IDNameDomain) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.revokeTeam(ClassDB.IDNameDomain)
    TO ClassDB_Instructor, ClassDB_DBManager;
+
+
+
+--Define a function to drop a team
+CREATE OR REPLACE FUNCTION 
+   ClassDB.dropTeam(teamName ClassDB.IDNameDomain,
+                    dropFromServer BOOLEAN DEFAULT FALSE,
+                    okIfRemainsClassDBRoleMember BOOLEAN DEFAULT TRUE,
+                    objectsDisposition VARCHAR DEFAULT 'assign',
+                    newObjectsOwnerName ClassDB.IDNameDomain DEFAULT NULL)
+   RETURNS VOID AS
+$$
+BEGIN
+   --revoke team role (also asserts that teamName is a known team)
+   PERFORM ClassDB.revokeTeam($1);
+   
+   --drop team
+   PERFORM ClassDB.dropRole($1, $2, $3, $4, $5);
+END;
+$$ LANGUAGE plpgsql
+   SECURITY DEFINER;
+
+
+--Change function ownership and set permissions
+ALTER FUNCTION
+   ClassDB.dropTeam(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN, VARCHAR,
+                    ClassDB.IDNameDomain)
+   OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION
+   ClassDB.dropTeam(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN, VARCHAR,
+                    ClassDB.IDNameDomain)
+   FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION
+   ClassDB.dropTeam(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN, VARCHAR,
+                    ClassDB.IDNameDomain)
+   TO ClassDB_Instructor, ClassDB_DBManager;
+
 
 
 COMMIT;

--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -534,7 +534,7 @@ CREATE OR REPLACE FUNCTION
 $$
 BEGIN
    --record ClassDB role
-   PERFORM ClassDB.createRole($1, COALESCE($2, teamName), TRUE, $3, $4, $5, $6);
+   PERFORM ClassDB.createRole($1, $2, TRUE, $3, $4, $5, $6);
    
    --get name of role's schema (possibly not the original value of schemaName)
    $3 = ClassDB.getSchemaName($1);

--- a/src/db/core/addRoleBaseMgmtCore.sql
+++ b/src/db/core/addRoleBaseMgmtCore.sql
@@ -343,9 +343,9 @@ REVOKE ALL ON FUNCTION
 
 
 
---Define a function to revoke a ClassDB role from a known user
+--Define a function to revoke a ClassDB role from a known ClassDB role
 CREATE OR REPLACE FUNCTION
-   ClassDB.revokeClassDBRole(userName ClassDB.IDNameDomain,
+   ClassDB.revokeClassDBRole(roleName ClassDB.IDNameDomain,
                              classdbRoleName ClassDB.IDNameDomain)
    RETURNS VOID AS
 $$
@@ -359,23 +359,23 @@ BEGIN
 
    --should be a server role
    IF NOT ClassDB.isServerRoleDefined($1) THEN
-      RAISE NOTICE 'User "%" is not defined in the server', $1;
+      RAISE NOTICE 'Role "%" is not defined in the server', $1;
       RETURN;
    END IF;
 
-   --should be a known user
-   IF NOT ClassDB.isUser($1) THEN
-      RAISE NOTICE 'User "%" is not known', $1;
+   --should be a known role
+   IF NOT ClassDB.isRoleKnown($1) THEN
+      RAISE NOTICE 'Role "%" is not known', $1;
       RETURN;
    END IF;
 
-   --user should already have the role to revoke
+   --role should already have the group role to revoke
    IF NOT ClassDB.isMember($1, $2) THEN
-      RAISE NOTICE 'User "%" is not a member of role "%"', $1, $2;
+      RAISE NOTICE 'Role "%" is not a member of ClassDB role "%"', $1, $2;
       RETURN;
    END IF;
 
-   --revoke the specified ClassDB role from the user
+   --revoke the specified ClassDB role from the role
    EXECUTE FORMAT('REVOKE %s FROM %s', $2, $1);
 
 END;

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -479,25 +479,25 @@ $$
 BEGIN
    --Minimal test: Schema should be set to teamName
    PERFORM ClassDB.createTeam('testTeam0');
-   
+
    --Name and extra info given
    PERFORM ClassDB.createTeam('testTeam1', 'Test team 1', NULL, 'Test info');
-   
-   --Updating with different schema: Create team, create schema, then update
+
+   --Updating name and schema: Create team, create schema, then update
    PERFORM ClassDB.createTeam('testTeam2', 'Previous name');
    CREATE SCHEMA newTestTeam2 AUTHORIZATION testTeam2;
    SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.createTeam('testTeam2', 'Test team 2');
    RESET client_min_messages;
-   
+
    --Test role membership (and existence)
    IF NOT(pg_has_role('testTeam0', 'classdb_team', 'member')
       AND pg_has_role('testTeam1', 'classdb_team', 'member')
-     AND pg_has_role('testTeam2', 'classdb_team', 'member'))
+      AND pg_has_role('testTeam2', 'classdb_team', 'member'))
    THEN
       RETURN 'FAIL: Code 1';
    END IF;
-   
+
    --Test existence of all schemas
    IF NOT(pg_temp.isSchemaDefined('testTeam0')
       AND pg_temp.isSchemaDefined('testTeam1')
@@ -506,7 +506,7 @@ BEGIN
    THEN
       RETURN 'FAIL: Code 2';
    END IF;
-   
+
    --Test role-schema correspondence with ClassDB function
    IF NOT(ClassDB.getSchemaName('testTeam0') = ClassDB.foldPgID('testTeam0')
       AND ClassDB.getSchemaName('testTeam1') = ClassDB.foldPgID('testTeam1')
@@ -514,7 +514,7 @@ BEGIN
    THEN
       RETURN 'FAIL: Code 3';
    END IF;
-     
+
    --Test extra info stored for each team
    IF NOT(pg_temp.checkRoleInfo('testTeam0', NULL, NULL)
       AND pg_temp.checkRoleInfo('testTeam1', 'Test team 1', 'Test info')
@@ -522,12 +522,12 @@ BEGIN
    THEN
       RETURN 'FAIL: Code 4';
    END IF;
-   
-   --Test login privilege
+
+   --Test lack of login privilege
    IF EXISTS(
       SELECT * FROM pg_catalog.pg_roles
-      WHERE rolName IN (ClassDB.foldPgID('testTeam0'), 
-                        ClassDB.foldPgID('testTeam1'), 
+      WHERE rolName IN (ClassDB.foldPgID('testTeam0'),
+                        ClassDB.foldPgID('testTeam1'),
                         ClassDB.foldPgID('testTeam2'))
             AND rolCanLogin
             )
@@ -539,15 +539,15 @@ BEGIN
    DROP OWNED BY testTeam0;
    DROP ROLE testTeam0;
    DELETE FROM ClassDB.RoleBase WHERE roleName = ClassDB.foldPgID('testTeam0');
-   
+
    DROP OWNED BY testTeam1;
    DROP ROLE testTeam1;
    DELETE FROM ClassDB.RoleBase WHERE roleName = ClassDB.foldPgID('testTeam1');
-   
+
    DROP OWNED BY testTeam2;
    DROP ROLE testTeam2;
    DELETE FROM ClassDB.RoleBase WHERE roleName = ClassDB.foldPgID('testTeam2');
-   
+
    RETURN 'PASS';
 END;
 $$ LANGUAGE plpgsql;

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -1000,93 +1000,6 @@ END;
 $$ LANGUAGE plpgsql;
 
 
-CREATE OR REPLACE FUNCTION pg_temp.dropTeamTest() RETURNS TEXT AS
-$$
-BEGIN
-   --Basic teams
-   PERFORM ClassDB.createTeam('testTeam0', 'Test team 0');
-   PERFORM ClassDB.createTeam('testTeam1', 'Test team 1');
-   PERFORM ClassDB.createTeam('testTeam2', 'Test team 2');
-   PERFORM ClassDB.createTeam('testTeam3', 'Test team 3');
-
-   --ExtraInfo provided, then create additional schema owned by team
-   PERFORM ClassDB.createTeam('testTeam4', 'Test team 4', NULL, 'Info');
-   CREATE SCHEMA testSchema AUTHORIZATION testTeam4;
-   
-   --Create DB manager to handle default object disposition
-   PERFORM ClassDB.createDBManager('tempDBM0', 'Temporary DB manager 0');  
-   SET SESSION AUTHORIZATION tempDBM0;
-   
-   --Suppress NOTICEs about ownership reassignment
-   SET SESSION client_min_messages TO WARNING;
-
-   --Drop first team
-   PERFORM ClassDB.dropTeam('testTeam0');
-
-   --Drop second team, including dropping from server
-   PERFORM ClassDB.dropTeam('testTeam1', TRUE);
-
-   --Manually drop server role for third team (must be done as superuser), then
-   -- from ClassDB (as DB manager again)
-   RESET SESSION AUTHORIZATION;
-   DROP OWNED BY testTeam2;
-   DROP ROLE testTeam2;
-
-   SET SESSION AUTHORIZATION tempDBM0;
-   PERFORM ClassDB.dropTeam('testTeam2');
-
-   --Drop server role and owned objects for fourth team
-   PERFORM ClassDB.dropTeam('testTeam3', TRUE, TRUE, 'drop_c');
-
-   --Drop fifth team, who has an additional non-ClassDB schema
-   PERFORM ClassDB.dropTeam('testTeam4');
-
-   --Switch back to superuser role before validating test cases
-   RESET SESSION AUTHORIZATION;
-   
-   --Turn all messages back on
-   RESET client_min_messages;
-   
-   --Check for correct existence of roles
-   IF    NOT ClassDB.isServerRoleDefined('testTeam0')
-      OR ClassDB.isServerRoleDefined('testTeam1')
-      OR ClassDB.isServerRoleDefined('testTeam2')
-      OR ClassDB.isServerRoleDefined('testTeam3')
-      OR NOT ClassDB.isServerRoleDefined('testTeam4')
-   THEN
-      RETURN 'FAIL: Code 1';
-   END IF;
-
-   --Check for existence of schemas
-   IF    NOT pg_temp.isSchemaDefined('testTeam0')
-      OR NOT pg_temp.isSchemaDefined('testTeam1')
-      OR pg_temp.isSchemaDefined('testTeam2')
-      OR pg_temp.isSchemaDefined('testTeam3')
-      OR NOT pg_temp.isSchemaDefined('testTeam4')
-      OR NOT pg_temp.isSchemaDefined('testSchema')
-   THEN
-      RETURN 'FAIL: Code 2';
-   END IF;
-
-   --Check for ownership of existing schemas
-   IF NOT(ClassDB.getSchemaOwnerName('testTeam0') = ClassDB.foldPgID('tempDBM0')
-      AND ClassDB.getSchemaOwnerName('testTeam1') = ClassDB.foldPgID('tempDBM0')
-      AND ClassDB.getSchemaOwnerName('testTeam4') = ClassDB.foldPgID('tempDBM0')
-      AND ClassDB.getSchemaOwnerName('testSchema') = ClassDB.foldPgID('tempDBM0'))
-   THEN
-      RETURN 'FAIL: Code 3';
-   END IF;
-
-   --Cleanup
-   DROP OWNED BY tempDBM0;
-   DROP ROLE testIns0, testTeam4, tempDBM0;
-   DELETE FROM ClassDB.RoleBase WHERE RoleName = ClassDB.foldPgID('tempDBM0');
-
-   RETURN 'PASS';
-END;
-$$ LANGUAGE plpgsql;
-
-
 CREATE OR REPLACE FUNCTION pg_temp.dropDBManagerTest() RETURNS TEXT AS
 $$
 BEGIN
@@ -1188,6 +1101,93 @@ END;
 $$ LANGUAGE plpgsql;
 
 
+CREATE OR REPLACE FUNCTION pg_temp.dropTeamTest() RETURNS TEXT AS
+$$
+BEGIN
+   --Basic teams
+   PERFORM ClassDB.createTeam('testTeam0', 'Test team 0');
+   PERFORM ClassDB.createTeam('testTeam1', 'Test team 1');
+   PERFORM ClassDB.createTeam('testTeam2', 'Test team 2');
+   PERFORM ClassDB.createTeam('testTeam3', 'Test team 3');
+
+   --ExtraInfo provided, then create additional schema owned by team
+   PERFORM ClassDB.createTeam('testTeam4', 'Test team 4', NULL, 'Info');
+   CREATE SCHEMA testSchema AUTHORIZATION testTeam4;
+   
+   --Create DB manager to handle default object disposition
+   PERFORM ClassDB.createDBManager('tempDBM0', 'Temporary DB manager 0');  
+   SET SESSION AUTHORIZATION tempDBM0;
+   
+   --Suppress NOTICEs about ownership reassignment
+   SET SESSION client_min_messages TO WARNING;
+
+   --Drop first team
+   PERFORM ClassDB.dropTeam('testTeam0');
+
+   --Drop second team, including dropping from server
+   PERFORM ClassDB.dropTeam('testTeam1', TRUE);
+
+   --Manually drop server role for third team (must be done as superuser), then
+   -- from ClassDB (as DB manager again)
+   RESET SESSION AUTHORIZATION;
+   DROP OWNED BY testTeam2;
+   DROP ROLE testTeam2;
+
+   SET SESSION AUTHORIZATION tempDBM0;
+   PERFORM ClassDB.dropTeam('testTeam2');
+
+   --Drop server role and owned objects for fourth team
+   PERFORM ClassDB.dropTeam('testTeam3', TRUE, TRUE, 'drop_c');
+
+   --Drop fifth team, who has an additional non-ClassDB schema
+   PERFORM ClassDB.dropTeam('testTeam4');
+
+   --Switch back to superuser role before validating test cases
+   RESET SESSION AUTHORIZATION;
+   
+   --Turn all messages back on
+   RESET client_min_messages;
+   
+   --Check for correct existence of roles
+   IF    NOT ClassDB.isServerRoleDefined('testTeam0')
+      OR ClassDB.isServerRoleDefined('testTeam1')
+      OR ClassDB.isServerRoleDefined('testTeam2')
+      OR ClassDB.isServerRoleDefined('testTeam3')
+      OR NOT ClassDB.isServerRoleDefined('testTeam4')
+   THEN
+      RETURN 'FAIL: Code 1';
+   END IF;
+
+   --Check for existence of schemas
+   IF    NOT pg_temp.isSchemaDefined('testTeam0')
+      OR NOT pg_temp.isSchemaDefined('testTeam1')
+      OR pg_temp.isSchemaDefined('testTeam2')
+      OR pg_temp.isSchemaDefined('testTeam3')
+      OR NOT pg_temp.isSchemaDefined('testTeam4')
+      OR NOT pg_temp.isSchemaDefined('testSchema')
+   THEN
+      RETURN 'FAIL: Code 2';
+   END IF;
+
+   --Check for ownership of existing schemas
+   IF NOT(ClassDB.getSchemaOwnerName('testTeam0') = ClassDB.foldPgID('tempDBM0')
+      AND ClassDB.getSchemaOwnerName('testTeam1') = ClassDB.foldPgID('tempDBM0')
+      AND ClassDB.getSchemaOwnerName('testTeam4') = ClassDB.foldPgID('tempDBM0')
+      AND ClassDB.getSchemaOwnerName('testSchema') = ClassDB.foldPgID('tempDBM0'))
+   THEN
+      RETURN 'FAIL: Code 3';
+   END IF;
+
+   --Cleanup
+   DROP OWNED BY tempDBM0;
+   DROP ROLE testIns0, testTeam4, tempDBM0;
+   DELETE FROM ClassDB.RoleBase WHERE RoleName = ClassDB.foldPgID('tempDBM0');
+
+   RETURN 'PASS';
+END;
+$$ LANGUAGE plpgsql;
+
+
 CREATE OR REPLACE FUNCTION pg_temp.dropAllStudentsTest() RETURNS TEXT AS
 $$
 BEGIN
@@ -1261,6 +1261,72 @@ END;
 $$ LANGUAGE plpgsql;
 
 
+CREATE OR REPLACE FUNCTION pg_temp.dropAllTeamsTest() RETURNS TEXT AS
+$$
+BEGIN
+   --Create two test teams
+   PERFORM ClassDB.createTeam('team0_dropAllTeams', 'Test team 0');
+   PERFORM ClassDB.createTeam('team1_dropAllTeams', 'Test team 1');
+   
+   --Create DB manager to handle default object disposition
+   PERFORM ClassDB.createDBManager('DBM0_dropAllTeams', 'Temp DB manager 0');  
+   SET SESSION AUTHORIZATION DBM0_dropAllTeams;
+
+   --Minimal drop
+   PERFORM ClassDB.dropAllTeams();
+   
+   --Reset back to superuser role for test case validation
+   RESET SESSION AUTHORIZATION;
+
+   --Check for correct existence of roles
+   IF    NOT ClassDB.isServerRoleDefined('team0_dropAllTeams')
+      OR NOT ClassDB.isServerRoleDefined('team1_dropAllTeams')
+   THEN
+      RETURN 'FAIL: Code 1';
+   END IF;
+
+   --Check for existence of schemas
+   IF    NOT pg_temp.isSchemaDefined('team0_dropAllTeams')
+      OR NOT pg_temp.isSchemaDefined('team1_dropAllTeams')
+   THEN
+      RETURN 'FAIL: Code 2';
+   END IF;
+
+   --Check for ownership of existing schemas
+   IF NOT(ClassDB.getSchemaOwnerName('team0_dropAllTeams') 
+                                    = ClassDB.foldPgID('DBM0_dropAllTeams')
+      AND ClassDB.getSchemaOwnerName('team1_dropAllTeams') 
+                                    = ClassDB.foldPgID('DBM0_dropAllTeams'))
+   THEN
+      RETURN 'FAIL: Code 3';
+   END IF;
+
+   --Create two more test teams
+   PERFORM ClassDB.createTeam('team2_dropAllTeams', 'Test team 2');
+   PERFORM ClassDB.createTeam('team3_dropAllTeams', 'Test team 3');
+
+   --Drop from server and drop owned objects
+   PERFORM ClassDB.dropAllTeams(TRUE, FALSE, 'drop_c');
+
+   --Check for correct existence of roles
+   IF    ClassDB.isServerRoleDefined('team2_dropAllTeams')
+      OR ClassDB.isServerRoleDefined('team3_dropAllTeams')
+   THEN
+      RETURN 'FAIL: Code 4';
+   END IF;
+
+   --Check for existence of schemas
+   IF    pg_temp.isSchemaDefined('team2_dropAllTeams')
+      OR pg_temp.isSchemaDefined('team3_dropAllTeams')
+   THEN
+      RETURN 'FAIL: Code 5';
+   END IF;
+   
+   RETURN 'PASS';
+END;
+$$ LANGUAGE plgpsql;
+
+
 CREATE OR REPLACE FUNCTION pg_temp.prepareClassDBTest() RETURNS VOID AS
 $$
 BEGIN
@@ -1277,6 +1343,7 @@ BEGIN
    RAISE INFO '%   dropDBManagerTest()', pg_temp.dropDBManagerTest();
    RAISE INFO '%   dropTeamTest()', pg_temp.dropTeamTest();
    RAISE INFO '%   dropAllStudentsTest()', pg_temp.dropAllStudentsTest();
+   RAISE INFO '%   dropAllTeamsTest()', pg_temp.dropAllTeamsTest();
 END;
 $$  LANGUAGE plpgsql;
 

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -770,9 +770,6 @@ BEGIN
    THEN
       RETURN 'FAIL: Code 3';
    END IF;
-   
-   --Create team, add students, then revoke
-   --RETURN 'FAIL: Code xx Not Implemented';
 
    RETURN 'PASS';
 END;

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -740,7 +740,7 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION pg_temp.revokeTeamTest() RETURNS TEXT AS
 $$
 BEGIN
-   --Create basic DB manager, then revoke
+   --Create team with name, then revoke
    PERFORM ClassDB.createTeam('team0_revokeTeam', 'Test team 0');
    PERFORM ClassDB.revokeTeam('team0_revokeTeam');
    
@@ -1127,7 +1127,7 @@ BEGIN
    RESET client_min_messages;
    
    --Check for correct existence of roles
-   IF    NOT ClassDB.isServerRoleDefined('team0_dropTeam')
+   IF NOT ClassDB.isServerRoleDefined('team0_dropTeam')
       OR ClassDB.isServerRoleDefined('team1_dropTeam')
       OR ClassDB.isServerRoleDefined('team2_dropTeam')
       OR ClassDB.isServerRoleDefined('team3_dropTeam')
@@ -1137,7 +1137,7 @@ BEGIN
    END IF;
 
    --Check for existence of schemas
-   IF    NOT pg_temp.isSchemaDefined('team0_dropTeam')
+   IF NOT pg_temp.isSchemaDefined('team0_dropTeam')
       OR NOT pg_temp.isSchemaDefined('team1_dropTeam')
       OR pg_temp.isSchemaDefined('team2_dropTeam')
       OR pg_temp.isSchemaDefined('team3_dropTeam')

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -1248,8 +1248,10 @@ BEGIN
    PERFORM ClassDB.createDBManager('DBM0_dropAllTeams', 'Temp DB manager 0');  
    SET SESSION AUTHORIZATION DBM0_dropAllTeams;
 
-   --Minimal drop
+   --Minimal drop, NOTICEs are silenced
+   SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.dropAllTeams();
+   RESET client_min_messages;
    
    --Reset back to superuser role for test case validation
    RESET SESSION AUTHORIZATION;
@@ -1281,8 +1283,10 @@ BEGIN
    PERFORM ClassDB.createTeam('team2_dropAllTeams', 'Test team 2');
    PERFORM ClassDB.createTeam('team3_dropAllTeams', 'Test team 3');
 
-   --Drop from server and drop owned objects
+   --Drop from server and drop owned objects, NOTICEs are silenced
+   SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.dropAllTeams(TRUE, FALSE, 'drop_c');
+   RESET client_min_messages;
 
    --Check for correct existence of roles
    IF    ClassDB.isServerRoleDefined('team2_dropAllTeams')

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -485,7 +485,7 @@ BEGIN
 
    --Creating team with pre-owned schema
    CREATE ROLE team2_createTeam;
-   CREATE SCHEMA newSchema_createTeam AUTHORIZATION team2_createTeam;
+   CREATE SCHEMA nonDefaultSchema_createTeam AUTHORIZATION team2_createTeam;
    SET LOCAL client_min_messages TO WARNING;
    PERFORM ClassDB.createTeam('team2_createTeam', 'Test team 2',
                               'nonDefaultSchema_createTeam');


### PR DESCRIPTION
This PR focuses on adding functions to create, revoke, and drop teams in ClassDB. In particular, it leaves out functionality that manages team membership, which will be added in a separate PR due to the large number of changes.

Unit tests for all 4 functions have been created, and all pass on my instance except for `testCreateTeam()`, which fails with Code 4 due to a pending decision related to optional `fullName`s (see Issue #218). Currently, if a `fullName` is not provided, it is set to `teamName` (final behavior will depend on the decision made in #218, as such, **do not approve this PR** until then).

As @smurthys discussed in PR #211, the tests in `testClassDBRolesMgmt.sql` need several improvements in relation to avoiding unnecessary operations and improving consistency. The new tests were created with these improvements in mind, but the rest of the test script has been left unchanged, leaving the improvements for future development.

Changes to privilege tests will wait for team membership functionality to be added.

Closes: #218, Closes: #219, Closes: #220