### PR TITLE
Add functions to get and compare server versions

### DIFF
--- a/src/db/core/addHelpersCore.sql
+++ b/src/db/core/addHelpersCore.sql
@@ -555,6 +555,8 @@ $$ LANGUAGE plpgsql
 ALTER FUNCTION
    ClassDB.compareServerVersion(VARCHAR, VARCHAR, BOOLEAN) OWNER TO ClassDB;
 
+--Limit to ClassDB to prevent exceptions due to incorrect args
+-- too much development effort to prevent all possible exceptions
 REVOKE ALL ON FUNCTION
    ClassDB.compareServerVersion(VARCHAR, VARCHAR, BOOLEAN) FROM PUBLIC;
 

--- a/src/db/core/addHelpersCore.sql
+++ b/src/db/core/addHelpersCore.sql
@@ -591,4 +591,52 @@ REVOKE ALL ON FUNCTION
 
 
 
+--Define a shortcut fn to test if the server's version precedes the given version
+CREATE OR REPLACE FUNCTION
+   ClassDB.isServerVersionBefore(version VARCHAR, testPart2 BOOLEAN DEFAULT TRUE)
+   RETURNS BOOLEAN AS
+$$
+   SELECT ClassDB.compareServerVersion($1, $2) > 0;
+$$ LANGUAGE sql
+   RETURNS NULL ON NULL INPUT;
+
+ALTER FUNCTION ClassDB.isServerVersionBefore(VARCHAR, BOOLEAN) OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION
+   ClassDB.isServerVersionBefore(VARCHAR, BOOLEAN) FROM PUBLIC;
+
+
+
+--Define a shortcut fn to test if the server's version succeeds the given version
+CREATE OR REPLACE FUNCTION
+   ClassDB.isServerVersionAfter(version VARCHAR, testPart2 BOOLEAN DEFAULT TRUE)
+   RETURNS BOOLEAN AS
+$$
+   SELECT ClassDB.compareServerVersion($1, $2) < 0;
+$$ LANGUAGE sql
+   RETURNS NULL ON NULL INPUT;
+
+ALTER FUNCTION ClassDB.isServerVersionAfter(VARCHAR, BOOLEAN) OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION
+   ClassDB.isServerVersionAfter(VARCHAR, BOOLEAN) FROM PUBLIC;
+
+
+
+--Define a shortcut fn to test if the server's version matches the given version
+CREATE OR REPLACE FUNCTION
+   ClassDB.isServerVersion(version VARCHAR, testPart2 BOOLEAN DEFAULT TRUE)
+   RETURNS BOOLEAN AS
+$$
+   SELECT ClassDB.compareServerVersion($1, $2) = 0;
+$$ LANGUAGE sql
+   RETURNS NULL ON NULL INPUT;
+
+ALTER FUNCTION ClassDB.isServerVersion(VARCHAR, BOOLEAN) OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION
+   ClassDB.isServerVersion(VARCHAR, BOOLEAN) FROM PUBLIC;
+
+
+
 COMMIT;

--- a/src/db/core/addHelpersCore.sql
+++ b/src/db/core/addHelpersCore.sql
@@ -497,7 +497,7 @@ ALTER FUNCTION ClassDB.getServerVersion() OWNER TO ClassDB;
 --Define a function to compare any two Postgres server version numbers
 --Compatible with Postgres versioning policy
 -- https://www.postgresql.org/support/versioning
---Optionally tests the second part in a version number, e.g.: '6' in '9.6'
+--Optionally ignores the second part in a version number, e.g.: '6' in '9.6'
 --Always ignores third part of a version number, e.g., ignores the 3 in "9.6.3"
 --Return value:
 -- simply returns the integer difference between corresponding parts of version#
@@ -506,7 +506,7 @@ ALTER FUNCTION ClassDB.getServerVersion() OWNER TO ClassDB;
 -- zero if the two versions are the same
 CREATE OR REPLACE FUNCTION
    ClassDB.compareServerVersion(version1 VARCHAR, version2 VARCHAR,
-                                testPart2 BOOLEAN DEFAULT FALSE
+                                testPart2 BOOLEAN DEFAULT TRUE
                                )
    RETURNS INTEGER AS
 $$
@@ -523,7 +523,7 @@ BEGIN
    END IF;
 
    $2 = TRIM($2);
-   IF ($1 = '') THEN
+   IF ($2 = '') THEN
       RAISE EXCEPTION 'invalid argument: version2 is empty';
    END IF;
 
@@ -532,7 +532,7 @@ BEGIN
    $1 = TRIM(split_part($1, '(', 1));
    $2 = TRIM(split_part($2, '(', 1));
 
-   --adjust version numbers such that they always have two parts
+   --adjust version numbers to always have two parts so later code is easier
    -- e.g., change '10' to '10.0'
    IF (POSITION('.' IN $1) = 0) THEN
       $1 = $1 || '.0';
@@ -576,7 +576,7 @@ REVOKE ALL ON FUNCTION
 --See version of this fn that compares any two server version numbers for details
 CREATE OR REPLACE FUNCTION
    ClassDB.compareServerVersion(version1 VARCHAR,
-                                testPart2 BOOLEAN DEFAULT FALSE
+                                testPart2 BOOLEAN DEFAULT TRUE
                                )
    RETURNS INTEGER AS
 $$
@@ -588,5 +588,7 @@ ALTER FUNCTION ClassDB.compareServerVersion(VARCHAR, BOOLEAN) OWNER TO ClassDB;
 
 REVOKE ALL ON FUNCTION
    ClassDB.compareServerVersion(VARCHAR, BOOLEAN) FROM PUBLIC;
+
+
 
 COMMIT;

--- a/tests/testHelpers.sql
+++ b/tests/testHelpers.sql
@@ -200,12 +200,12 @@ BEGIN
       RETURN 'FAIL: Code 2';
    END IF;
 
-   --test function to test any two version numbers: ignore part 2
-   IF ClassDB.compareServerVersion('9.6', '9.5') <> 0 THEN
+   --test any two version numbers: test part 2
+   IF ClassDB.compareServerVersion('9.6', '9.5') <= 0 THEN
       RETURN 'FAIL: Code 3';
    END IF;
 
-   IF ClassDB.compareServerVersion('9.5', '9.6') <> 0 THEN
+   IF ClassDB.compareServerVersion('9.5', '9.6') >= 0 THEN
       RETURN 'FAIL: Code 4';
    END IF;
 
@@ -217,7 +217,7 @@ BEGIN
       RETURN 'FAIL: Code 6';
    END IF;
 
-   --test function to test any two version numbers: test distro suffix
+   --test any two version numbers: test distro suffix
    IF ClassDB.compareServerVersion('10.3', '10.3 (Ubuntu 10.3-1)') <> 0 THEN
       RETURN 'FAIL: Code 7';
    END IF;
@@ -227,37 +227,37 @@ BEGIN
    END IF;
 
    --intentionally no space before opening parenthesis
-   IF ClassDB.compareServerVersion('10.1(distro 1)', '10.2(distro 2)') <> 0 THEN
+   IF ClassDB.compareServerVersion('10.1(distro 1)', '10.2(distro 2)') >= 0 THEN
       RETURN 'FAIL: Code 9';
    END IF;
 
-   --test function to test any two version numbers: test part 2
-   IF ClassDB.compareServerVersion('9.6', '9.6', TRUE) <> 0 THEN
+   --test any two version numbers: ignore part 2
+   IF ClassDB.compareServerVersion('9.6', '9.6', FALSE) <> 0 THEN
       RETURN 'FAIL: Code 10';
    END IF;
 
-   IF ClassDB.compareServerVersion('9.6', '9.5', TRUE) <= 0 THEN
+   IF ClassDB.compareServerVersion('9.6', '9.5', FALSE) <> 0 THEN
       RETURN 'FAIL: Code 11';
    END IF;
 
-   IF ClassDB.compareServerVersion('9.5', '9.6', TRUE) >= 0 THEN
+   IF ClassDB.compareServerVersion('9.5', '9.6', FALSE) <> 0 THEN
       RETURN 'FAIL: Code 12';
    END IF;
 
-   --test function to test any two version numbers: single-part input
-   IF ClassDB.compareServerVersion('10', '10', TRUE) <> 0 THEN
+   --test any two version numbers: single-part input
+   IF ClassDB.compareServerVersion('10', '10', FALSE) <> 0 THEN
       RETURN 'FAIL: Code 13';
    END IF;
 
-   IF ClassDB.compareServerVersion('10', '9.5', TRUE) <= 0 THEN
+   IF ClassDB.compareServerVersion('10', '9.5', FALSE) <= 0 THEN
       RETURN 'FAIL: Code 14';
    END IF;
 
-   IF ClassDB.compareServerVersion('9.5', '10', TRUE) >= 0 THEN
+   IF ClassDB.compareServerVersion('9.5', '10', FALSE) >= 0 THEN
       RETURN 'FAIL: Code 15';
    END IF;
 
-   --test function to test any version number with server's version number
+   --test some version number with server's version number
    IF ClassDB.compareServerVersion('9.5')
       <>
       ClassDB.compareServerVersion('9.5', current_setting('server_version'))

--- a/tests/testHelpers.sql
+++ b/tests/testHelpers.sql
@@ -213,30 +213,44 @@ BEGIN
       RETURN 'FAIL: Code 6';
    END IF;
 
-   --test function to test any two version numbers: test part 2
-   IF ClassDB.compareServerVersion('9.6', '9.6', TRUE) <> 0 THEN
+   --test function to test any two version numbers: test distro suffix
+   IF ClassDB.compareServerVersion('10.3', '10.3 (Ubuntu 10.3-1)') <> 0 THEN
       RETURN 'FAIL: Code 7';
    END IF;
 
-   IF ClassDB.compareServerVersion('9.6', '9.5', TRUE) <= 0 THEN
+   IF ClassDB.compareServerVersion('10.3 (Ubuntu 10.3-1)', '10.3') <> 0 THEN
       RETURN 'FAIL: Code 8';
    END IF;
 
-   IF ClassDB.compareServerVersion('9.5', '9.6', TRUE) >= 0 THEN
+   --intentionally no space before opening parenthesis
+   IF ClassDB.compareServerVersion('10.1(distro 1)', '10.2(distro 2)') <> 0 THEN
       RETURN 'FAIL: Code 9';
+   END IF;
+
+   --test function to test any two version numbers: test part 2
+   IF ClassDB.compareServerVersion('9.6', '9.6', TRUE) <> 0 THEN
+      RETURN 'FAIL: Code 10';
+   END IF;
+
+   IF ClassDB.compareServerVersion('9.6', '9.5', TRUE) <= 0 THEN
+      RETURN 'FAIL: Code 11';
+   END IF;
+
+   IF ClassDB.compareServerVersion('9.5', '9.6', TRUE) >= 0 THEN
+      RETURN 'FAIL: Code 12';
    END IF;
 
    --test function to test any two version numbers: single-part input
    IF ClassDB.compareServerVersion('10', '10', TRUE) <> 0 THEN
-      RETURN 'FAIL: Code 10';
+      RETURN 'FAIL: Code 13';
    END IF;
 
    IF ClassDB.compareServerVersion('10', '9.5', TRUE) <= 0 THEN
-      RETURN 'FAIL: Code 11';
+      RETURN 'FAIL: Code 14';
    END IF;
 
    IF ClassDB.compareServerVersion('9.5', '10', TRUE) >= 0 THEN
-      RETURN 'FAIL: Code 12';
+      RETURN 'FAIL: Code 15';
    END IF;
 
    --test function to test any version number with server's version number
@@ -244,7 +258,7 @@ BEGIN
       <>
       ClassDB.compareServerVersion('9.5', current_setting('server_version'))
    THEN
-      RETURN 'FAIL: Code 13';
+      RETURN 'FAIL: Code 16';
    END IF;
 
    RETURN 'PASS';

--- a/tests/testHelpers.sql
+++ b/tests/testHelpers.sql
@@ -265,6 +265,41 @@ BEGIN
       RETURN 'FAIL: Code 16';
    END IF;
 
+   --shortcut functions
+   IF ClassDB.isServerVersionBefore('0') THEN
+      RETURN 'FAIL: Code 17';
+   END IF;
+
+   IF ClassDB.isServerVersionBefore('0', FALSE) THEN
+      RETURN 'FAIL: Code 18';
+   END IF;
+
+   IF NOT ClassDB.isServerVersionAfter('0') THEN
+      RETURN 'FAIL: Code 19';
+   END IF;
+
+   IF NOT ClassDB.isServerVersionAfter('0', FALSE) THEN
+      RETURN 'FAIL: Code 20';
+   END IF;
+
+   IF NOT ClassDB.isServerVersion(current_setting('server_version')) THEN
+      RETURN 'FAIL: Code 21';
+   END IF;
+
+   IF ClassDB.isServerVersion('0.8') THEN
+      RETURN 'FAIL: Code 22';
+   END IF;
+
+   --the following tests fail when Postgres version reaches 100000.8
+   -- just change the argument at that point, or rewrite the tests
+   IF NOT ClassDB.isServerVersionBefore('100000.8') THEN
+      RETURN 'FAIL: Code 23';
+   END IF;
+
+   IF ClassDB.isServerVersionAfter('100000.8') THEN
+      RETURN 'FAIL: Code 24';
+   END IF;
+
    RETURN 'PASS';
 END;
 $$ LANGUAGE plpgsql;

--- a/tests/testHelpers.sql
+++ b/tests/testHelpers.sql
@@ -192,7 +192,11 @@ BEGIN
    END IF;
 
    --test function to return server's version number
-   IF ClassDB.getServerVersion() <> current_setting('server_version') THEN
+   --can't test equality because value from current_setting can have distro suffix
+   -- instead, test if value from current_setting starts with server version
+   IF POSITION(ClassDB.getServerVersion()
+      IN current_setting('server_version')) <> 1
+   THEN
       RETURN 'FAIL: Code 2';
    END IF;
 


### PR DESCRIPTION
This PR adds the following functions:
- `getServerSetting` get any server setting by name
- `getServerVersion` to get server's version number
- `compareServerVersion` to compare a version number with current server's, or compare any two version numbers

I am still working on a test script for these changes.

Closes #231