### PR TITLE
Guard IF NOT EXISTS in CREATE INDEX for pre-pg9.5

### DIFF
--- a/src/db/core/addHelpersCore.sql
+++ b/src/db/core/addHelpersCore.sql
@@ -461,29 +461,182 @@ ALTER FUNCTION
 
 
 
---Define a function to retrieve specific capabilities a user has
--- use this function to get status of different capabilities in one call
+--Define a function to get the value of any server setting
+--Queries the catalog view pg_settings to avoid exceptions if the setting name
+-- supplied is not found
+--Returns NULL if the setting name supplied is not found
+CREATE OR REPLACE FUNCTION
+   ClassDB.getServerSetting(settingName VARCHAR)
+   RETURNS VARCHAR AS
+$$
+   SELECT setting FROM pg_catalog.pg_settings
+   WHERE name = $1;
+$$ LANGUAGE sql
+   RETURNS NULL ON NULL INPUT;
 
---Commenting out the function because a unit test is yet to be developed
---CREATE OR REPLACE FUNCTION
---   ClassDB.getRoleCapabilities(roleName ClassDB.IDNameDomain,
---                               OUT isSuperUser BOOLEAN,
---                               OUT hasCreateRole BOOLEAN,
---                               OUT canCreateDatabase BOOLEAN)
---   AS
---$$
---BEGIN
---   SELECT rolsuper, rolcreaterole, rolcreatedb FROM pg_catalog.pg_roles
---   WHERE rolname = $1;
---END;
---$$ LANGUAGE plpgsql;
+ALTER FUNCTION ClassDB.getServerSetting(VARCHAR) OWNER TO ClassDB;
 
---ALTER FUNCTION
---   ClassDB.getRoleCapabilities(roleName ClassDB.IDNameDomain,
---                               OUT isSuperUser BOOLEAN,
---                               OUT hasCreateRole BOOLEAN,
---                               OUT canCreateDatabase BOOLEAN)
---   OWNER TO ClassDB;
+
+
+--Define a function to get the server's version number
+--Removes additional info a distro may have suffixed to the version number
+-- e.g., Ubuntu's distro is known to return '10.3 (Ubuntu 10.3-1)', whereas
+-- a Postgres distro returns just '10.3'
+CREATE OR REPLACE FUNCTION ClassDB.getServerVersion()
+   RETURNS VARCHAR AS
+$$
+   --get value of setting 'server_version' and remove any distro-added suffix
+   SELECT TRIM(split_part(ClassDB.getServerSetting('server_version'), '(', 1));
+$$ LANGUAGE sql
+   RETURNS NULL ON NULL INPUT;
+
+ALTER FUNCTION ClassDB.getServerVersion() OWNER TO ClassDB;
+
+
+
+--Define a function to compare any two Postgres server version numbers
+--Compatible with Postgres versioning policy
+-- https://www.postgresql.org/support/versioning
+--Optionally ignores the second part in a version number, e.g.: '6' in '9.6'
+--Always ignores third part of a version number, e.g., ignores the 3 in "9.6.3"
+--Return value:
+-- simply returns the integer difference between corresponding parts of version#
+-- negative number if version1 precedes version2
+-- positive number if version1 succeeds version2
+-- zero if the two versions are the same
+CREATE OR REPLACE FUNCTION
+   ClassDB.compareServerVersion(version1 VARCHAR, version2 VARCHAR,
+                                testPart2 BOOLEAN DEFAULT TRUE
+                               )
+   RETURNS INTEGER AS
+$$
+DECLARE
+   verson1Parts VARCHAR ARRAY;
+   verson2Parts VARCHAR ARRAY;
+   major1 INTEGER;
+   major2 INTEGER;
+BEGIN
+
+   $1 = TRIM($1);
+   IF ($1 = '') THEN
+      RAISE EXCEPTION 'invalid argument: version1 is empty';
+   END IF;
+
+   $2 = TRIM($2);
+   IF ($2 = '') THEN
+      RAISE EXCEPTION 'invalid argument: version2 is empty';
+   END IF;
+
+   --remove any distro-specific suffix from the version number
+   -- see function getServerVersion for details
+   $1 = TRIM(split_part($1, '(', 1));
+   $2 = TRIM(split_part($2, '(', 1));
+
+   --adjust version numbers to always have two parts so later code is easier
+   -- e.g., change '10' to '10.0'
+   IF (POSITION('.' IN $1) = 0) THEN
+      $1 = $1 || '.0';
+   END IF;
+
+   IF (POSITION('.' IN $2) = 0) THEN
+      $2 = $2 || '.0';
+   END IF;
+
+   --convert each version number to an array for ease of comparison
+   verson1Parts = string_to_array($1, '.');
+   verson2Parts = string_to_array($2, '.');
+
+   --cast the major version number (e.g., '9' in '9.6') to a number
+   -- causes exception if input is not really numeric
+   major1 = TRIM(verson1Parts[1])::INTEGER;
+   major2 = TRIM(verson2Parts[1])::INTEGER;
+
+   IF (major1 <> major2) THEN
+      RETURN major1 - major2;
+   ELSIF $3 THEN
+      RETURN TRIM(verson1Parts[2])::INTEGER - TRIM(verson2Parts[2])::INTEGER;
+   ELSE
+      RETURN 0;
+   END IF;
+
+END;
+$$ LANGUAGE plpgsql
+   RETURNS NULL ON NULL INPUT;
+
+ALTER FUNCTION
+   ClassDB.compareServerVersion(VARCHAR, VARCHAR, BOOLEAN) OWNER TO ClassDB;
+
+--Limit to ClassDB to prevent exceptions due to incorrect args
+-- too much development effort to prevent all possible exceptions
+REVOKE ALL ON FUNCTION
+   ClassDB.compareServerVersion(VARCHAR, VARCHAR, BOOLEAN) FROM PUBLIC;
+
+
+--Define a function to compare some Postgres server version number to this server's
+--See version of this fn that compares any two server version numbers for details
+CREATE OR REPLACE FUNCTION
+   ClassDB.compareServerVersion(version1 VARCHAR,
+                                testPart2 BOOLEAN DEFAULT TRUE
+                               )
+   RETURNS INTEGER AS
+$$
+   SELECT ClassDB.compareServerVersion($1, ClassDB.getServerVersion(), $2);
+$$ LANGUAGE sql
+   RETURNS NULL ON NULL INPUT;
+
+ALTER FUNCTION ClassDB.compareServerVersion(VARCHAR, BOOLEAN) OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION
+   ClassDB.compareServerVersion(VARCHAR, BOOLEAN) FROM PUBLIC;
+
+
+
+--Define a shortcut fn to test if the server's version precedes the given version
+CREATE OR REPLACE FUNCTION
+   ClassDB.isServerVersionBefore(version VARCHAR, testPart2 BOOLEAN DEFAULT TRUE)
+   RETURNS BOOLEAN AS
+$$
+   SELECT ClassDB.compareServerVersion($1, $2) > 0;
+$$ LANGUAGE sql
+   RETURNS NULL ON NULL INPUT;
+
+ALTER FUNCTION ClassDB.isServerVersionBefore(VARCHAR, BOOLEAN) OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION
+   ClassDB.isServerVersionBefore(VARCHAR, BOOLEAN) FROM PUBLIC;
+
+
+
+--Define a shortcut fn to test if the server's version succeeds the given version
+CREATE OR REPLACE FUNCTION
+   ClassDB.isServerVersionAfter(version VARCHAR, testPart2 BOOLEAN DEFAULT TRUE)
+   RETURNS BOOLEAN AS
+$$
+   SELECT ClassDB.compareServerVersion($1, $2) < 0;
+$$ LANGUAGE sql
+   RETURNS NULL ON NULL INPUT;
+
+ALTER FUNCTION ClassDB.isServerVersionAfter(VARCHAR, BOOLEAN) OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION
+   ClassDB.isServerVersionAfter(VARCHAR, BOOLEAN) FROM PUBLIC;
+
+
+
+--Define a shortcut fn to test if the server's version matches the given version
+CREATE OR REPLACE FUNCTION
+   ClassDB.isServerVersion(version VARCHAR, testPart2 BOOLEAN DEFAULT TRUE)
+   RETURNS BOOLEAN AS
+$$
+   SELECT ClassDB.compareServerVersion($1, $2) = 0;
+$$ LANGUAGE sql
+   RETURNS NULL ON NULL INPUT;
+
+ALTER FUNCTION ClassDB.isServerVersion(VARCHAR, BOOLEAN) OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION
+   ClassDB.isServerVersion(VARCHAR, BOOLEAN) FROM PUBLIC;
+
 
 
 COMMIT;

--- a/src/db/core/addRoleBaseMgmtCore.sql
+++ b/src/db/core/addRoleBaseMgmtCore.sql
@@ -58,8 +58,31 @@ CREATE TABLE IF NOT EXISTS ClassDB.RoleBase
 
 --Define a unique index on the folded version of role name
 -- this approach to uniqueness makes RoleName compatible w/ Postgres role names
-CREATE UNIQUE INDEX IF NOT EXISTS idx_Unique_FoldedRoleName
-ON ClassDB.RoleBase(ClassDB.foldPgID(RoleName));
+
+--Guard the use of IF NOT EXISTS because that option was introduced in pg 9.5
+--Remove the guarded code when ClassDB support for pg versions prior to 9.5 stops
+DO
+$$
+BEGIN
+   IF ClassDB.isServerVersionBefore('9.5') THEN
+      --works on any pg version, but intentionally guarding for pre-9.5 versions
+      -- so it is easier to remove the code later
+      IF NOT EXISTS (SELECT indexname FROM pg_catalog.pg_indexes
+                     WHERE schemaname = 'classdb'
+                          AND tablename = 'rolebase'
+                          AND indexname = 'idx_unique_foldedrolename'
+                    )
+      THEN
+         CREATE UNIQUE INDEX idx_Unique_FoldedRoleName
+         ON ClassDB.RoleBase(ClassDB.foldPgID(RoleName));
+      END IF;
+   ELSE
+      --works on pg9.5 or later
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_Unique_FoldedRoleName
+      ON ClassDB.RoleBase(ClassDB.foldPgID(RoleName));
+   END IF;
+END
+$$;
 
 --Change table's owner so ClassDB can perform any operation on it
 ALTER TABLE ClassDB.RoleBase OWNER TO ClassDB;

--- a/tests/testHelpers.sql
+++ b/tests/testHelpers.sql
@@ -177,6 +177,135 @@ END;
 $$ LANGUAGE plpgsql;
 
 
+
+--Define a temporary function to test functions related to server settings
+CREATE OR REPLACE FUNCTION pg_temp.testServerSettings() RETURNS TEXT AS
+$$
+BEGIN
+
+   --test function to get any setting
+   IF ClassDB.getServerSetting('server_version')
+      <>
+      current_setting('server_version')
+   THEN
+      RETURN 'FAIL: Code 1';
+   END IF;
+
+   --test function to return server's version number
+   --can't test equality because value from current_setting can have distro suffix
+   -- instead, test if value from current_setting starts with server version
+   IF POSITION(ClassDB.getServerVersion()
+      IN current_setting('server_version')) <> 1
+   THEN
+      RETURN 'FAIL: Code 2';
+   END IF;
+
+   --test any two version numbers: test part 2
+   IF ClassDB.compareServerVersion('9.6', '9.5') <= 0 THEN
+      RETURN 'FAIL: Code 3';
+   END IF;
+
+   IF ClassDB.compareServerVersion('9.5', '9.6') >= 0 THEN
+      RETURN 'FAIL: Code 4';
+   END IF;
+
+   IF ClassDB.compareServerVersion('8.5', '9.6') >= 0 THEN
+      RETURN 'FAIL: Code 5';
+   END IF;
+
+   IF ClassDB.compareServerVersion('9.6', '8.5') <= 0 THEN
+      RETURN 'FAIL: Code 6';
+   END IF;
+
+   --test any two version numbers: test distro suffix
+   IF ClassDB.compareServerVersion('10.3', '10.3 (Ubuntu 10.3-1)') <> 0 THEN
+      RETURN 'FAIL: Code 7';
+   END IF;
+
+   IF ClassDB.compareServerVersion('10.3 (Ubuntu 10.3-1)', '10.3') <> 0 THEN
+      RETURN 'FAIL: Code 8';
+   END IF;
+
+   --intentionally no space before opening parenthesis
+   IF ClassDB.compareServerVersion('10.1(distro 1)', '10.2(distro 2)') >= 0 THEN
+      RETURN 'FAIL: Code 9';
+   END IF;
+
+   --test any two version numbers: ignore part 2
+   IF ClassDB.compareServerVersion('9.6', '9.6', FALSE) <> 0 THEN
+      RETURN 'FAIL: Code 10';
+   END IF;
+
+   IF ClassDB.compareServerVersion('9.6', '9.5', FALSE) <> 0 THEN
+      RETURN 'FAIL: Code 11';
+   END IF;
+
+   IF ClassDB.compareServerVersion('9.5', '9.6', FALSE) <> 0 THEN
+      RETURN 'FAIL: Code 12';
+   END IF;
+
+   --test any two version numbers: single-part input
+   IF ClassDB.compareServerVersion('10', '10', FALSE) <> 0 THEN
+      RETURN 'FAIL: Code 13';
+   END IF;
+
+   IF ClassDB.compareServerVersion('10', '9.5', FALSE) <= 0 THEN
+      RETURN 'FAIL: Code 14';
+   END IF;
+
+   IF ClassDB.compareServerVersion('9.5', '10', FALSE) >= 0 THEN
+      RETURN 'FAIL: Code 15';
+   END IF;
+
+   --test some version number with server's version number
+   IF ClassDB.compareServerVersion('9.5')
+      <>
+      ClassDB.compareServerVersion('9.5', current_setting('server_version'))
+   THEN
+      RETURN 'FAIL: Code 16';
+   END IF;
+
+   --shortcut functions
+   IF ClassDB.isServerVersionBefore('0') THEN
+      RETURN 'FAIL: Code 17';
+   END IF;
+
+   IF ClassDB.isServerVersionBefore('0', FALSE) THEN
+      RETURN 'FAIL: Code 18';
+   END IF;
+
+   IF NOT ClassDB.isServerVersionAfter('0') THEN
+      RETURN 'FAIL: Code 19';
+   END IF;
+
+   IF NOT ClassDB.isServerVersionAfter('0', FALSE) THEN
+      RETURN 'FAIL: Code 20';
+   END IF;
+
+   IF NOT ClassDB.isServerVersion(current_setting('server_version')) THEN
+      RETURN 'FAIL: Code 21';
+   END IF;
+
+   IF ClassDB.isServerVersion('0.8') THEN
+      RETURN 'FAIL: Code 22';
+   END IF;
+
+   --the following tests fail when Postgres version reaches 100000.8
+   -- just change the argument at that point, or rewrite the tests
+   IF NOT ClassDB.isServerVersionBefore('100000.8') THEN
+      RETURN 'FAIL: Code 23';
+   END IF;
+
+   IF ClassDB.isServerVersionAfter('100000.8') THEN
+      RETURN 'FAIL: Code 24';
+   END IF;
+
+   RETURN 'PASS';
+END;
+$$ LANGUAGE plpgsql;
+
+
+
 --Define a temporary function to test miscellaneous functions
 -- only one function to test as of now
 CREATE OR REPLACE FUNCTION pg_temp.testMiscellany() RETURNS TEXT AS
@@ -200,11 +329,8 @@ BEGIN
    --test if schema owner's name is retrieved
    CREATE SCHEMA tset_amehcs_iierr8;
    IF ClassDB.getSchemaOwnerName('tset_amehcs_iierr8') <> CURRENT_USER THEN
-      DROP SCHEMA tset_amehcs_iierr8;
       RETURN 'FAIL: Code 3';
    END IF;
-   DROP SCHEMA tset_amehcs_iierr8;
-
 
    RETURN 'PASS';
 END;
@@ -245,8 +371,9 @@ BEGIN
    RAISE INFO '%   testMembership',
       pg_temp.testMembership();
 
-   DROP USER testUser1_Login;
-   DROP USER testUser2_NoLogin;
+   --test functions related to server settings
+   RAISE INFO '%   testServerSettings',
+      pg_temp.testServerSettings();
 
    --test functions not tested so far
    RAISE INFO '%   Miscellany',
@@ -259,4 +386,4 @@ $$  LANGUAGE plpgsql;
 SELECT pg_temp.testHelperFunctions();
 
 
-COMMIT;
+ROLLBACK;


### PR DESCRIPTION
The changes in this PR guard the use of `IF NOT EXISTS` in `CREATE INDEX`. 

The changes work in pg9.6, **but need to be tested in pg9.3 or 9.4 as well as in 10.x**. 

Fixes #230 

BTW, these changes give a glimpse of the code structure we might need to make the product compatible with Postgre versions prior to 9.6
