### PR TITLE
Add Team Views

### DIFF
--- a/src/db/core/addClassDBRolesViewsCore.sql
+++ b/src/db/core/addClassDBRolesViewsCore.sql
@@ -135,7 +135,7 @@ GRANT SELECT ON ClassDB.DBManager TO ClassDB_Instructor, ClassDB_DBManager;
 -- creates a derived table containing all teams for a self-join
 CREATE OR REPLACE VIEW ClassDB.TeamMember AS
   SELECT Team.RoleName Team, Member.RoleName Member
-  FROM Classdb.RoleBase Member
+  FROM ClassDB.RoleBase Member
   JOIN ClassDB.RoleBase Team ON ClassDB.isMember(Member.RoleName, Team.RoleName)
   WHERE NOT Member.IsTeam AND Team.IsTeam
   ORDER BY Team;
@@ -147,7 +147,7 @@ GRANT SELECT ON ClassDB.TeamMember TO ClassDB_Instructor, ClassDB_DBManager;
 
 --Define a view to return known teams with thier RoleName, FullName, SchemaName,
 -- ExtraInfo and Member count
--- creates derived a table w/ team-specific aggregate MemberCount over the view
+-- uses a scalar-value sub-query to computer the MemberCount using the view
 -- ClassDB.TeamMember
 CREATE OR REPLACE VIEW ClassDB.Team AS
   SELECT RoleName AS TeamName,

--- a/src/db/core/addClassDBRolesViewsCore.sql
+++ b/src/db/core/addClassDBRolesViewsCore.sql
@@ -131,6 +131,7 @@ ALTER VIEW ClassDB.DBManager OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.DBManager FROM PUBLIC;
 GRANT SELECT ON ClassDB.DBManager TO ClassDB_Instructor, ClassDB_DBManager;
 
+
 --Define a view to return Team members and thier respective team
 -- creates a derived table containing all teams for a self-join
 CREATE OR REPLACE VIEW ClassDB.TeamMember AS
@@ -144,6 +145,7 @@ CREATE OR REPLACE VIEW ClassDB.TeamMember AS
 ALTER VIEW ClassDB.TeamMember OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.User FROM PUBLIC;
 GRANT SELECT ON ClassDB.TeamMember TO ClassDB_Instructor, ClassDB_DBManager;
+
 
 --Define a view to return known teams with thier RoleName, FullName, SchemaName,
 -- ExtraInfo and Member count


### PR DESCRIPTION
Adds the team views: ClassDB.Team and ClassDB.TeamMember. Fixes #236 

The view TeamMember displays all roles that are added to a team and their respective team(s).

The view Team displays all teams with their attributes and an aggregate `MemberCount`.

In order to test this properly the `ClassDB.addToTeam` function from branch `add-teams-membership` will need to be added.

I added it manually to my local ClassDB and everything seems to working properly. 