### PR TITLE
Add teams membership

### DIFF
--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -669,6 +669,7 @@ GRANT EXECUTE ON FUNCTION
    TO ClassDB_Instructor, ClassDB_DBManager;
 
 
+
 --Define function to drop all known teams
 CREATE OR REPLACE FUNCTION
    ClassDB.dropAllTeams(dropFromServer BOOLEAN DEFAULT FALSE,
@@ -700,5 +701,177 @@ GRANT EXECUTE ON FUNCTION
                         ClassDB.IDNameDomain)
    TO ClassDB_Instructor, ClassDB_DBManager;
 
+
+
+--Define a function to add a student to a team
+--Asserts that studentName is a known student and teamName is a known team
+--Grants team role to student and sets privileges, allowing for access to team's
+-- data, and team access to data the student makes in the team's schema
+CREATE OR REPLACE FUNCTION ClassDB.addToTeam(studentName ClassDB.IDNameDomain,
+                                             teamName ClassDB.IDNameDomain)
+   RETURNS VOID AS
+$$
+BEGIN
+   --assert that studentName is a known student
+   IF NOT ClassDB.isStudent($1) THEN
+      RAISE EXCEPTION 'Role "%" is not a known student', $1;
+   END IF;
+   
+   --assert that teamName is a known team
+   IF NOT ClassDB.isTeam($2) THEN
+      RAISE EXCEPTION 'Role "%" is not a known team', $2;
+   END IF;
+   
+   --grant team to student
+   PERFORM ClassDB.grantRole($2, $1);
+   
+   --change default privileges to allow all members to read/modify data
+   EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                  ' GRANT ALL PRIVILEGES ON TABLES TO %s',
+                     $1, ClassDB.getSchemaName($2), $2);
+   EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                  ' GRANT ALL PRIVILEGES ON SEQUENCES TO %s',
+                     $1, ClassDB.getSchemaName($2), $2);
+   EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                  ' GRANT ALL PRIVILEGES ON FUNCTIONS TO %s',
+                     $1, ClassDB.getSchemaName($2), $2);
+   EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                  ' GRANT ALL PRIVILEGES ON TYPES TO %s',
+                     $1, ClassDB.getSchemaName($2), $2);
+                     
+   --change default privileges to allow instructors to read data
+   EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                  ' GRANT SELECT ON TABLES TO ClassDB_Instructor',
+                     $1, ClassDB.getSchemaName($2));
+   EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                  ' GRANT USAGE ON SEQUENCES TO ClassDB_Instructor',
+                     $1, ClassDB.getSchemaName($2));
+   EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                  ' GRANT EXECUTE ON FUNCTIONS TO ClassDB_Instructor',
+                     $1, ClassDB.getSchemaName($2));
+   EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                  ' GRANT USAGE ON TYPES TO ClassDB_Instructor',
+                     $1, ClassDB.getSchemaName($2));
+END;
+$$ LANGUAGE plpgsql
+   SECURITY DEFINER;
+
+--Change function ownership and set permissions
+ALTER FUNCTION ClassDB.addToTeam(ClassDB.IDNameDomain, ClassDB.IDNameDomain) 
+   OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION
+   ClassDB.addToTeam(ClassDB.IDNameDomain, ClassDB.IDNameDomain) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION
+   ClassDB.addToTeam(ClassDB.IDNameDomain, ClassDB.IDNameDomain)
+   TO ClassDB_Instructor, ClassDB_DBManager;
+
+
+
+--Define a function to remove a student from a team
+--Asserts that studentName is a known student and teamName is a known team
+--Revokes privileges, preventing students from accessing shared team data, but 
+--  leaves any data the student may have created in the team's schema
+CREATE OR REPLACE FUNCTION 
+   ClassDB.removeFromTeam(studentName ClassDB.IDNameDomain,
+                          teamName ClassDB.IDNameDomain) 
+   RETURNS VOID AS
+$$
+BEGIN
+   --assert that studentName is a known student
+   IF NOT ClassDB.isStudent($1) THEN
+      RAISE EXCEPTION 'Role "%" is not a known student', $1;
+   END IF;
+   
+   --assert that teamName is a known team
+   IF NOT ClassDB.isTeam($2) THEN
+      RAISE EXCEPTION 'Role "%" is not a known team', $2;
+   END IF;
+   
+   --revoke privileges to role and unset default privileges
+   IF ClassDB.isMember($1, $2) THEN
+      --remove default privileges that allowed all members to read/modify data 
+      -- created by this student in the team's schema
+      EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                     ' REVOKE ALL PRIVILEGES ON TABLES FROM %s',
+                        $1, ClassDB.getSchemaName($2), $2);
+      EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                     ' REVOKE ALL PRIVILEGES ON SEQUENCES FROM %s',
+                        $1, ClassDB.getSchemaName($2), $2);
+      EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                     ' REVOKE ALL PRIVILEGES ON FUNCTIONS FROM %s',
+                        $1, ClassDB.getSchemaName($2), $2);
+      EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                     ' REVOKE ALL PRIVILEGES ON TYPES FROM %s',
+                        $1, ClassDB.getSchemaName($2), $2);
+      
+      --remove default privileges that allowed instructors to read data created 
+      -- by this student in the team's schema
+      EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                     ' REVOKE SELECT ON TABLES FROM ClassDB_Instructor',
+                        $1, ClassDB.getSchemaName($2));
+      EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                     ' REVOKE USAGE ON SEQUENCES FROM ClassDB_Instructor',
+                        $1, ClassDB.getSchemaName($2));
+      EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                     ' REVOKE EXECUTE ON FUNCTIONS FROM ClassDB_Instructor',
+                        $1, ClassDB.getSchemaName($2));
+      EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
+                     ' REVOKE USAGE ON TYPES FROM ClassDB_Instructor',
+                        $1, ClassDB.getSchemaName($2));
+      
+      --Transfer ownership of team objects that were owned by the member being
+      -- removed. This avoid issues with future DROP/REASSIGN OWNED BY that
+      -- target the removed member (such as when a user is dropped from ClassDB)
+      
+      
+      --revoke team from student
+      EXECUTE FORMAT('REVOKE %s FROM %s', $2, $1);
+   ELSE
+      RAISE NOTICE 'Student "%" is not a member of "%"', $1, $2;
+   END IF;
+END;
+$$ LANGUAGE plpgsql
+   SECURITY DEFINER;
+   
+
+--Change function ownership and set permissions
+ALTER FUNCTION
+   ClassDB.removeFromTeam(ClassDB.IDNameDomain, ClassDB.IDNameDomain) 
+   OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION
+   ClassDB.removeFromTeam(ClassDB.IDNameDomain, ClassDB.IDNameDomain)
+   FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION
+   ClassDB.removeFromTeam(ClassDB.IDNameDomain, ClassDB.IDNameDomain)
+   TO ClassDB_Instructor, ClassDB_DBManager;
+
+
+
+--Define a function to remove all students registers to a team
+--The function calls ClassDB.removeFromTeam for every student who is a member
+CREATE OR REPLACE FUNCTION 
+   ClassDB.removeAllFromTeam(teamName ClassDB.IDNameDomain) RETURNS VOID AS
+$$
+BEGIN
+   PERFORM ClassDB.removeFromTeam(R.roleName, $1)
+   FROM ClassDB.RoleBase R
+   WHERE ClassDB.isStudent(R.roleName) AND ClassDB.isMember(R.roleName, $1);
+END;
+$$ LANGUAGE plpgsql
+   SECURITY DEFINER;
+
+
+--Change function ownership and set permissions
+ALTER FUNCTION ClassDB.removeAllFromTeam(ClassDB.IDNameDomain) OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION ClassDB.removeAllFromTeam(ClassDB.IDNameDomain)
+   FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION ClassDB.removeAllFromTeam(ClassDB.IDNameDomain)
+   TO ClassDB_Instructor, ClassDB_DBManager;
 
 COMMIT;

--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -824,7 +824,7 @@ BEGIN
       --Transfer ownership of team objects that were owned by the member being
       -- removed. This avoid issues with future DROP/REASSIGN OWNED BY that
       -- target the removed member (such as when a user is dropped from ClassDB)
-      
+      --PERFORM ClassDB.reassignOwnedInSchema(ClassDB.getSchemaName($2), $1, $2);
       
       --revoke team from student
       EXECUTE FORMAT('REVOKE %s FROM %s', $2, $1);

--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -824,7 +824,7 @@ BEGIN
       --Transfer ownership of team objects that were owned by the member being
       -- removed. This avoid issues with future DROP/REASSIGN OWNED BY that
       -- target the removed member (such as when a user is dropped from ClassDB)
-      --PERFORM ClassDB.reassignOwnedInSchema(ClassDB.getSchemaName($2), $1, $2);
+      PERFORM ClassDB.reassignOwnedInSchema(ClassDB.getSchemaName($2), $1, $2);
       
       --revoke team from student
       EXECUTE FORMAT('REVOKE %s FROM %s', $2, $1);

--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -711,6 +711,8 @@ CREATE OR REPLACE FUNCTION ClassDB.addToTeam(studentName ClassDB.IDNameDomain,
                                              teamName ClassDB.IDNameDomain)
    RETURNS VOID AS
 $$
+DECLARE
+   teamSchema ClassDB.IDNameDomain; --name of shared team schema
 BEGIN
    --assert that studentName is a known student
    IF NOT ClassDB.isStudent($1) THEN
@@ -725,33 +727,36 @@ BEGIN
    --grant team to student
    PERFORM ClassDB.grantRole($2, $1);
    
+   --get name of team's schema
+   teamSchema = ClassDB.getSchemaName($2);
+   
    --change default privileges to allow all members to read/modify data
    EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                   ' GRANT ALL PRIVILEGES ON TABLES TO %s',
-                     $1, ClassDB.getSchemaName($2), $2);
+                     $1, teamSchema, $2);
    EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                   ' GRANT ALL PRIVILEGES ON SEQUENCES TO %s',
-                     $1, ClassDB.getSchemaName($2), $2);
+                     $1, teamSchema, $2);
    EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                   ' GRANT ALL PRIVILEGES ON FUNCTIONS TO %s',
-                     $1, ClassDB.getSchemaName($2), $2);
+                     $1, teamSchema, $2);
    EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                   ' GRANT ALL PRIVILEGES ON TYPES TO %s',
-                     $1, ClassDB.getSchemaName($2), $2);
+                     $1, teamSchema, $2);
                      
    --change default privileges to allow instructors to read data
    EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                   ' GRANT SELECT ON TABLES TO ClassDB_Instructor',
-                     $1, ClassDB.getSchemaName($2));
+                     $1, teamSchema);
    EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                   ' GRANT USAGE ON SEQUENCES TO ClassDB_Instructor',
-                     $1, ClassDB.getSchemaName($2));
+                     $1, teamSchema);
    EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                   ' GRANT EXECUTE ON FUNCTIONS TO ClassDB_Instructor',
-                     $1, ClassDB.getSchemaName($2));
+                     $1, teamSchema);
    EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                   ' GRANT USAGE ON TYPES TO ClassDB_Instructor',
-                     $1, ClassDB.getSchemaName($2));
+                     $1, teamSchema);
 END;
 $$ LANGUAGE plpgsql
    SECURITY DEFINER;
@@ -778,6 +783,8 @@ CREATE OR REPLACE FUNCTION
                           teamName ClassDB.IDNameDomain) 
    RETURNS VOID AS
 $$
+DECLARE
+   teamSchema ClassDB.IDNameDomain; --name of shared team schema
 BEGIN
    --assert that studentName is a known student
    IF NOT ClassDB.isStudent($1) THEN
@@ -789,42 +796,45 @@ BEGIN
       RAISE EXCEPTION 'Role "%" is not a known team', $2;
    END IF;
    
+   --get name of team's schema
+   teamSchema = ClassDB.getSchemaName($2);
+   
    --revoke privileges to role and unset default privileges
    IF ClassDB.isMember($1, $2) THEN
       --remove default privileges that allowed all members to read/modify data 
       -- created by this student in the team's schema
       EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                      ' REVOKE ALL PRIVILEGES ON TABLES FROM %s',
-                        $1, ClassDB.getSchemaName($2), $2);
+                        $1, teamSchema, $2);
       EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                      ' REVOKE ALL PRIVILEGES ON SEQUENCES FROM %s',
-                        $1, ClassDB.getSchemaName($2), $2);
+                        $1, teamSchema, $2);
       EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                      ' REVOKE ALL PRIVILEGES ON FUNCTIONS FROM %s',
-                        $1, ClassDB.getSchemaName($2), $2);
+                        $1, teamSchema, $2);
       EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                      ' REVOKE ALL PRIVILEGES ON TYPES FROM %s',
-                        $1, ClassDB.getSchemaName($2), $2);
+                        $1, teamSchema, $2);
       
       --remove default privileges that allowed instructors to read data created 
       -- by this student in the team's schema
       EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                      ' REVOKE SELECT ON TABLES FROM ClassDB_Instructor',
-                        $1, ClassDB.getSchemaName($2));
+                        $1, teamSchema);
       EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                      ' REVOKE USAGE ON SEQUENCES FROM ClassDB_Instructor',
-                        $1, ClassDB.getSchemaName($2));
+                        $1, teamSchema);
       EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                      ' REVOKE EXECUTE ON FUNCTIONS FROM ClassDB_Instructor',
-                        $1, ClassDB.getSchemaName($2));
+                        $1, teamSchema);
       EXECUTE FORMAT('ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s'
                      ' REVOKE USAGE ON TYPES FROM ClassDB_Instructor',
-                        $1, ClassDB.getSchemaName($2));
+                        $1, teamSchema);
       
       --Transfer ownership of team objects that were owned by the member being
       -- removed. This avoid issues with future DROP/REASSIGN OWNED BY that
       -- target the removed member (such as when a user is dropped from ClassDB)
-      PERFORM ClassDB.reassignOwnedInSchema(ClassDB.getSchemaName($2), $1, $2);
+      PERFORM ClassDB.reassignOwnedInSchema(teamSchema, $1, $2);
       
       --revoke team from student
       EXECUTE FORMAT('REVOKE %s FROM %s', $2, $1);

--- a/src/db/core/addHelpersCore.sql
+++ b/src/db/core/addHelpersCore.sql
@@ -362,7 +362,7 @@ $$
    CASE --Output the full name of each relation type from the char code
       WHEN c.relkind = 'r' THEN 'Table'
       WHEN c.relkind = 'i' THEN 'Index'
-      WHEN c.relkind = 's' THEN 'Sequence'
+      WHEN c.relkind = 'S' THEN 'Sequence'
       WHEN c.relkind = 'v' THEN 'View'
       WHEN c.relkind = 'm' THEN 'Materialized View'
       WHEN c.relkind = 'c' THEN 'Type'

--- a/src/db/core/addHelpersCore.sql
+++ b/src/db/core/addHelpersCore.sql
@@ -450,14 +450,11 @@ GRANT EXECUTE ON FUNCTION ClassDB.listOrphanObjects(ClassDB.IDNameDomain)
 --objectName must be an object in the current db, schema qualified if necessary
 -- IMPORTANT: objectNames for functions must have parameters
 --newOwner must be a valid server role
---okIfNotExists determines whether exceptions are raised if the object does not
--- exist (if true, notices are raised if the object does not exist)
 CREATE OR REPLACE FUNCTION
    ClassDB.reassignObjectOwnership(objectType VARCHAR(20),
                                    objectName VARCHAR,
                                    newOwner ClassDB.IDNameDomain
-                                    DEFAULT CURRENT_USER,
-                                   okIfNotExists BOOLEAN DEFAULT FALSE
+                                    DEFAULT CURRENT_USER
                                   )
    RETURNS VOID AS
 $$
@@ -503,13 +500,7 @@ BEGIN
    --execute command to reassign ownership. A separate statement is used for
    -- tables to avoid reassigning descendant tables
    IF $1 = 'TABLE' THEN
-      IF $4 THEN
-         EXECUTE FORMAT('ALTER TABLE IF EXISTS ONLY %s OWNER TO %s', $2, $3);
-      ELSE
-         EXECUTE FORMAT('ALTER TABLE ONLY %s OWNER TO %s', $2, $3);
-      END IF;
-   ELSEIF $4 THEN
-      EXECUTE FORMAT('ALTER %s IF EXISTS %s OWNER TO %s', $1, $2, $3);
+      EXECUTE FORMAT('ALTER TABLE ONLY %s OWNER TO %s', $2, $3);
    ELSE
       EXECUTE FORMAT('ALTER %s %s OWNER TO %s', $1, $2, $3);
    END IF;
@@ -518,7 +509,7 @@ $$ LANGUAGE plpgsql
    RETURNS NULL ON NULL INPUT;
 
 ALTER FUNCTION ClassDB.reassignObjectOwnership(VARCHAR, VARCHAR,
-                                               ClassDB.IDNameDomain, BOOLEAN)
+                                               ClassDB.IDNameDomain)
    OWNER TO ClassDB;
 
 

--- a/src/db/core/addHelpersCore.sql
+++ b/src/db/core/addHelpersCore.sql
@@ -461,22 +461,22 @@ $$
 BEGIN
    
    --stop if objectType matches TOAST table
-   $1 = LOWER(TRIM($1));
-   IF $1 = 'toast' THEN
+   $1 = UPPER(TRIM($1));
+   IF $1 = 'TOAST' THEN
       RAISE WARNING 'ownership of a TOAST tables is managed through ownership' 
                     ' of its user table';
       RETURN;
    END IF;
    
    --stop if objectType matches Index
-   IF $1 = 'index' THEN
+   IF $1 = 'INDEX' THEN
       RAISE WARNING 'ownership of an index is managed though ownership of its'
                     ' underlying table';
       RETURN;
    END IF;
 
    --stop if objectType matches Foreign table (not tested)
-   IF $1 = 'foreign table' THEN
+   IF $1 = 'FOREIGN TABLE' THEN
       RAISE EXCEPTION 'transferring ownership of foreign tables is not currently'
                        ' supported'
             USING DETAIL = FORMAT('foreign table name: "%s" requested new owner:'
@@ -485,13 +485,9 @@ BEGIN
    END IF;
    
    --match value of objectType to objects types that can be reassigned
-   IF $1 = 'table' THEN $1 = 'TABLE';
-   ELSEIF $1 = 'sequence' THEN $1 = 'SEQUENCE';
-   ELSEIF $1 = 'view' THEN $1 = 'VIEW';
-   ELSEIF $1 = 'materialized view' THEN $1 = 'MATERIALIZED VIEW';
-   ELSEIF $1 = 'type' THEN $1 = 'TYPE';
-   ELSEIF $1 = 'function' THEN $1 = 'FUNCTION';
-   ELSE
+   IF $1 NOT IN ('TABLE', 'SEQUENCE', 'VIEW', 'MATERIALIZED VIEW', 'TYPE',
+                  'FUNCTION')
+   THEN
       --invalid type provided
       RAISE EXCEPTION 'objectType "%" is not a valid object type for'
                       ' ownership reassignment', $1;

--- a/tests/testHelpers.sql
+++ b/tests/testHelpers.sql
@@ -472,9 +472,8 @@ BEGIN
    
    RETURN 'PARTIAL PASS - not all functionalty tested';
 --------------------------------------------------------------------------------
---Test additional functionality, including default role (CURRENT_USER) and 
--- allowing of non-existent objects
 
+--Test additional functionality: default role (CURRENT_USER)
 
 --------------------------------------------------------------------------------
 --Misc. edge cases: different capitalizations, no objects in schema


### PR DESCRIPTION
This PR implements changes that allow students to become members of a team. Becoming a member of a team allows students to create and access objects in the team's shared schema.

In regards to team membership, three functions have been created: `addToTeam()`, `removeFromTeam()`, and `removeAllFromTeam()`. As discussed in PR #221 , `removeFromTeam()` also reassigns ownership of objects in the teams schema to the team whenever a student is removed. To do so, two other functions have been added: `reassignObjectOwnership()` and `reassignOwnedInSchema()`.

Tests have been created to verify the nominal functionality of the new functions. These tests could be expanded further, particularly for exceptional cases, but I believe the current tests will suffice for M3. 

A couple of semi-related changes were made:

- The `COMMIT` at the end of `testHelpers.sql` has been changed to a `ROLLBACK`. See PR #197 
- A tiny but incredibly difficult to trace down bug was fixed in `listOwnedObjects()`. See commit 86353bdeee54def133351d6e4f3c3afda14e99ba

Currently, not all object types are reassigned when removing a student from a team. This is due to a known limitation of `listOwnedObjects()`. The affected object types are relatively uncommon and can be addressed at a later point. Also note that while "foreign tables" are listed by `listOwnedObjects()`, they are not supported by `reassignObjectOwnership()`, since testing is not currently feasible.

Closes: #221 