### PR TITLE
update file names with correct names

### DIFF
--- a/src/db/core/addClassDBRolesViewsCore.sql
+++ b/src/db/core/addClassDBRolesViewsCore.sql
@@ -14,7 +14,7 @@
 --This script requires the current user to be a superuser
 
 --This script should be run in every database to which ClassDB is to be added
--- it should be run after running addClassDBRolesMgmt.sql
+-- it should be run after running addClassDBRolesMgmtCore.sql
 
 --This script creates views for User, Student, Instructor, DBManager and Teams
 -- views add derived attributes to the base data in the associated tables

--- a/src/db/core/addRoleBaseMgmtCore.sql
+++ b/src/db/core/addRoleBaseMgmtCore.sql
@@ -13,7 +13,7 @@
 
 --This script requires the current user to be a superuser
 
---This script should be run after addHelpers.sql
+--This script should be run after addHelpersCore.sql
 
 --This script creates the basic tables and procedures to manage ClassDB users
 

--- a/src/db/opt/addCatalogMgmtOpt.sql
+++ b/src/db/opt/addCatalogMgmtOpt.sql
@@ -14,7 +14,7 @@
 -- to the PUBLIC schema
 
 --This script should be run in every database to which ClassDB is to be added
--- it should be run after running addHelpers.sql
+-- it should be run after running addHelpersCore.sql
 
 --This script creates two publicly accessible functions, intended for students
 -- These functions provide an easy way for students to DESCRIBE a tables
@@ -33,7 +33,7 @@ SET LOCAL client_min_messages TO WARNING;
 -- This function is a duplicate of ClassDB.foldPgID(). Since students cannot access
 -- objects in the ClassDB schema, this version is required so that students can use
 -- the catalog management functions. Any change to foldPgID() must also be made to
--- the version in addHelpers.sql
+-- the version in addHelpersCore.sql
 CREATE OR REPLACE FUNCTION public.foldPgID(identifier VARCHAR(65))
 RETURNS VARCHAR(63) AS
 $$

--- a/src/db/reco/addConnectionMgmtReco.sql
+++ b/src/db/reco/addConnectionMgmtReco.sql
@@ -11,7 +11,7 @@
 
 --This script requires the current user to be a superuser
 
---This script should be run after initializeDB.sql
+--This script should be run after initializeDBCore.sql
 
 --This script will create procedures used to manage user connections.
 

--- a/src/db/reco/addDDLActivityLoggingReco.sql
+++ b/src/db/reco/addDDLActivityLoggingReco.sql
@@ -12,7 +12,7 @@
 
 --This script must be run as superuser.
 --This script should be run in every database in which DDL activity monitoring is required
--- it should be run after running addUserMgmt.sql
+-- it should be run after running addUserMgmtCore.sql
 
 --This script adds the ClassDB DDL statement monitoring system.  Two event triggers
 -- log the last DDL statement executed for each student in the student table

--- a/src/db/reco/addFrequentViewsReco.sql
+++ b/src/db/reco/addFrequentViewsReco.sql
@@ -14,7 +14,7 @@
 -- to the ClassDB and PUBLIC schemas
 
 --This script should be run in every database to which ClassDB is to be added
--- it should be run after running addUserMgmt.sql
+-- it should be run after running addUserMgmtCore.sql
 
 --This script creates several objects (we collectively refer to them as views) to
 -- display summary data related to student activity in the current database.

--- a/src/db/removeAllFromDB.sql
+++ b/src/db/removeAllFromDB.sql
@@ -122,7 +122,7 @@ BEGIN
    RAISE NOTICE 'Drop user schemas or adjust their privilege';
    RAISE NOTICE 'Adjust privileges on PUBLIC schema if appropriate';
    RAISE NOTICE 'Run DROP DATABASE statement to remove the database if appropriate';
-   RAISE NOTICE 'Run removeFromServer.sql after removing ClassDB '
+   RAISE NOTICE 'Run removeAllFromServer.sql after removing ClassDB '
                 'from other databases';
 END
 $$;

--- a/src/server/reco/disableConnectionLoggingReco.psql
+++ b/src/server/reco/disableConnectionLoggingReco.psql
@@ -21,7 +21,7 @@
 --This script uses ALTER SYSTEM statements to change the Postgres server log settings to
 -- disable the connection logging system. This script only stops connections from being
 -- logged. It does not revert log_destination and log_filname to the original settings
--- prior to running enableServerLogging.sql.
+-- prior to running enableConnectionLoggingReco.sql.
 
 --The following changes are made:
 -- log_connections TO 'off' stops user connections from being recorded in the server log

--- a/src/server/reco/enableConnectionLoggingReco.psql
+++ b/src/server/reco/enableConnectionLoggingReco.psql
@@ -11,7 +11,7 @@
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
 --This script must be run as superuser.
---This script must be run before addConnectionActivityLogging.sql.
+--This script must be run before addConnectionActivityLoggingReco.sql.
 -- This script only needs to be run once per server, however.
 
 --Additionally, this script must be run using a client that will send each statement

--- a/src/server/removeAllFromServer.sql
+++ b/src/server/removeAllFromServer.sql
@@ -15,7 +15,7 @@
 -- not all changes can be undone
 -- this script lists the changes an appropriate user has to perform separately
 
---This script must be run AFTER running removeFromDB.sql on all databases
+--This script must be run AFTER running removeAllFromDB.sql on all databases
 -- where ClassDB is installed
 
 --This script will NOT drop user roles
@@ -46,7 +46,7 @@ $$;
 SET LOCAL client_min_messages TO WARNING;
 
 --Drop app-specific roles
--- need to make sure that removeFromDB.sql is complete
+-- need to make sure that removeAllFromDB.sql is complete
 DROP ROLE IF EXISTS ClassDB_Instructor;
 DROP ROLE IF EXISTS ClassDB_DBManager;
 DROP ROLE IF EXISTS ClassDB_Student;

--- a/tests/testRoleBaseMgmt.sql
+++ b/tests/testRoleBaseMgmt.sql
@@ -13,7 +13,7 @@
 
 --This script should be run as a superuser
 
---This script tests the functionality in addRoleBaseMgmt.sql
+--This script tests the functionality in addRoleBaseMgmtCore.sql
 -- only nominal tests are covered presently
 -- need to plan a test for cases that should cause exceptions
 


### PR DESCRIPTION
Changed comments that use old filenames to the updated filenames. Fixes #212 

Also, removed the now unnecessary comment in `addClassDBRolesMgmtCore.sql` : 

`--This script should be run after addConnectionMgmt.sql`