### PR TITLE
Added getSessionID() to uninstaller

### DIFF
--- a/src/db/reco/addFrequentViewsReco.sql
+++ b/src/db/reco/addFrequentViewsReco.sql
@@ -37,6 +37,10 @@ BEGIN
 END
 $$;
 
+--Suppress NOTICE messages for this script only, this will not apply to functions
+-- defined within. This hides messages that are unimportant, but possibly confusing
+SET LOCAL client_min_messages TO WARNING;
+
 
 
 --UPGRADE FROM 2.0 TO 2.1

--- a/src/db/removeAllFromDB.sql
+++ b/src/db/removeAllFromDB.sql
@@ -101,6 +101,8 @@ DROP FUNCTION IF EXISTS ClassDB.importConnectionLog(DATE);
 DROP FUNCTION IF EXISTS ClassDB.disallowSchemaDrop();
 DROP FUNCTION IF EXISTS ClassDB.allowSchemaDrop();
 
+DROP FUNCTION IF EXISTS ClassDB.getSessionID();
+
 
 --Try to drop all ClassDB owned functions in ClassDB schema
 DROP OWNED BY ClassDB;


### PR DESCRIPTION
Adds manually removal of `ClassDB.getSessionID()` in the installer, because it is a superuser function. Also adds the message suppression to `addFrequentViewsReco.sql`, which I forgot to push before.