### PR TITLE
Fix testConnectionActivityLogging.psql when importing old logs

### DIFF
--- a/tests/testConnectionActivityLogging.psql
+++ b/tests/testConnectionActivityLogging.psql
@@ -145,7 +145,7 @@ BEGIN
    --We expect 5 connections and 4 disconnections (testins02 is still connected)
    IF (SELECT CASE WHEN numConnections <> 5 THEN TRUE ELSE FALSE END
        OR     CASE WHEN numDisconnections <> 4 THEN TRUE ELSE FALSE END
-       FROM ClassDB.importConnectionLog())
+       FROM ClassDB.importConnectionLog(CURRENT_DATE))
    THEN
       RAISE INFO 'FAIL: Code 1';
    ELSE


### PR DESCRIPTION
This fixes the observed errors in `testConnectionActivityLogging.psql` by limiting the second import to `CURRENT_DATE`. There may be a more robust way perform this test, but I would need more time to analyze the issue.

In a nutshell, I believe what was happening is that when there are connections in `ClassDB.ConnectionActivity` that are at least two days old, `importConnectionLog()` will always return more than one row. The issue arises when the first import is performed. If there are no current users with connection activity on the dates imported, then no rows are added to `ClassDB.ConnectionActivity`. Thus, when `importConnectionLog()` is run in the test proper, more than one row is returned, which is an error.

This is definitely a test design issue rather than a ClassDB issue, however.