### PR TITLE
Allow creation of schemas by ClassDB users

### DIFF
--- a/src/db/core/initializeDBCore.sql
+++ b/src/db/core/initializeDBCore.sql
@@ -85,7 +85,8 @@ BEGIN
 
    --Allow ClassDB to create schemas on the current database
    -- all schema-creation operations are done only by this role in this app
-   EXECUTE format('GRANT CREATE ON DATABASE %I TO ClassDB', currentDB);
+   EXECUTE format('GRANT CREATE ON DATABASE %I TO ClassDB, ClassDB_Instructor,'
+                  ' ClassDB_DBManager, ClassDB_Student', currentDB);
 END
 $$;
 

--- a/src/db/core/initializeDBCore.sql
+++ b/src/db/core/initializeDBCore.sql
@@ -83,8 +83,7 @@ BEGIN
    EXECUTE format('GRANT CONNECT ON DATABASE %I TO ClassDB_Instructor, '
                   'ClassDB_Student, ClassDB_DBManager', currentDB);
 
-   --Allow ClassDB to create schemas on the current database
-   -- all schema-creation operations are done only by this role in this app
+   --Allow ClassDB and ClassDB users to create schemas on the current database
    EXECUTE format('GRANT CREATE ON DATABASE %I TO ClassDB, ClassDB_Instructor,'
                   ' ClassDB_DBManager, ClassDB_Student', currentDB);
 END

--- a/tests/privileges/1_instructorPass.sql
+++ b/tests/privileges/1_instructorPass.sql
@@ -89,6 +89,10 @@ SET Col1 = 'goodbye';
 DELETE FROM public.PublicTest;
 DROP TABLE public.PublicTest;
 
+--Create and drop schema
+CREATE SCHEMA ptins0schema;
+DROP SCHEMA ptins0schema;
+
 
 --Read from columns in RoleBase table
 SELECT * FROM ClassDB.RoleBase;

--- a/tests/privileges/2_studentPass.sql
+++ b/tests/privileges/2_studentPass.sql
@@ -52,6 +52,8 @@ WHERE TRUE;
 DELETE FROM test;
 DROP TABLE test;
 
+--Create (but not drop) schema
+CREATE SCHEMA ptstu0schema;
 
 --CRUD on tables owned by student in team schema
 CREATE TABLE ptteam0.SharedTable

--- a/tests/privileges/3_dbmanagerPass.sql
+++ b/tests/privileges/3_dbmanagerPass.sql
@@ -68,6 +68,10 @@ SET col1 = 'goodbye';
 DELETE FROM Test;
 DROP TABLE Test;
 
+--Create and drop schema
+CREATE SCHEMA ptdbm0schema;
+DROP SCHEMA ptdbm0schema;
+
 
 --Read from columns in RoleBase table
 SELECT * FROM ClassDB.RoleBase;

--- a/tests/privileges/6_studentFail.sql
+++ b/tests/privileges/6_studentFail.sql
@@ -31,6 +31,8 @@ SELECT * FROM ptteam0.SharedTable;
 --Not create on team's schema
 CREATE TABLE ptteam0.StudentTestTable(col1 VARCHAR);
 
+--Not drop own schema
+DROP SCHEMA ptstu1;
 
 --Not access any objects in classdb schema, should be prevented by not having
 -- USAGE on the classdb schema anyway


### PR DESCRIPTION
Instructors, DBManagers, and Students can now create schemas. Students still cannot drop schemas.

Privilege tests were updated to test this functionality.

Closes: #251 