### PR TITLE
Guard CREATE INDEX IF NOT EXISTS for Postgres 9.4 or earlier

### DIFF
--- a/src/db/core/addRoleBaseMgmtCore.sql
+++ b/src/db/core/addRoleBaseMgmtCore.sql
@@ -91,9 +91,12 @@ BEGIN
          ON ClassDB.RoleBase(ClassDB.foldPgID(RoleName));
       END IF;
    ELSE
-      --works on pg9.5 or later: only this code needed when pg9.4 is unsupported
-      CREATE UNIQUE INDEX IF NOT EXISTS idx_Unique_FoldedRoleName
-      ON ClassDB.RoleBase(ClassDB.foldPgID(RoleName));
+      --query for pg9.5 or later: must be dynamic so it is not processed in
+      -- pre 9.5 versions; change to static (stop using EXECUTE) when pg9.4 is
+      -- no longer supported
+      EXECUTE
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_Unique_FoldedRoleName '
+      'ON ClassDB.RoleBase(ClassDB.foldPgID(RoleName));';
    END IF;
 END
 $$;

--- a/src/db/core/addRoleBaseMgmtCore.sql
+++ b/src/db/core/addRoleBaseMgmtCore.sql
@@ -70,10 +70,34 @@ CREATE TABLE IF NOT EXISTS ClassDB.RoleBase
   ExtraInfo VARCHAR --any additional information instructors wish to maintain
 );
 
+
 --Define a unique index on the folded version of role name
 -- this approach to uniqueness makes RoleName compatible w/ Postgres role names
-CREATE UNIQUE INDEX IF NOT EXISTS idx_Unique_FoldedRoleName
-ON ClassDB.RoleBase(ClassDB.foldPgID(RoleName));
+--Guard the use of IF NOT EXISTS because that option was introduced in pg 9.5
+--Remove the guarded code when ClassDB support for pg versions prior to 9.5 stops
+DO
+$$
+BEGIN
+   IF ClassDB.isServerVersionBefore('9.5') THEN
+      --works on any pg version, but intentionally guarding for pre-9.5 versions
+      -- so it is easier to remove the code later
+      IF NOT EXISTS (SELECT indexname FROM pg_catalog.pg_indexes
+                     WHERE schemaname = 'classdb'
+                          AND tablename = 'rolebase'
+                          AND indexname = 'idx_unique_foldedrolename'
+                    )
+      THEN
+         CREATE UNIQUE INDEX idx_Unique_FoldedRoleName
+         ON ClassDB.RoleBase(ClassDB.foldPgID(RoleName));
+      END IF;
+   ELSE
+      --works on pg9.5 or later: only this code needed when pg9.4 is unsupported
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_Unique_FoldedRoleName
+      ON ClassDB.RoleBase(ClassDB.foldPgID(RoleName));
+   END IF;
+END
+$$;
+
 
 --Change table's owner so ClassDB can perform any operation on it
 ALTER TABLE ClassDB.RoleBase OWNER TO ClassDB;

--- a/src/db/core/addUserMgmtCore.sql
+++ b/src/db/core/addUserMgmtCore.sql
@@ -155,7 +155,7 @@ GRANT SELECT ON ClassDB.ConnectionActivity
 --Remove this function and its use (see after fn definition) when the upgrade
 -- path is removed
 --ADD COLUMN and CREATE INDEX operations do not test IF NOT EXISTS because this
--- function is called only if none of the columns being added already exist
+-- function is called only if none of the columns specific to v2.1 exist
 CREATE OR REPLACE FUNCTION pg_temp.upgradeConnectionActivity_20_21()
 RETURNS VOID AS
 $$

--- a/src/db/core/addUserMgmtCore.sql
+++ b/src/db/core/addUserMgmtCore.sql
@@ -223,7 +223,7 @@ BEGIN
 
    --Column ApplicationName is new in v2.1
    ALTER TABLE IF EXISTS ClassDB.ConnectionActivity
-   ADD COLUMN IF NOT EXISTS ApplicationName ClassDB.IDNameDomain;
+   ADD COLUMN ApplicationName ClassDB.IDNameDomain;
 
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
This commit fixes #230 by using `CREATE INDEX IF NOT EXISTS` only if the server version is 9.5 or later.