### PR TITLE
Guard uses of pg_event_trigger_ddl_commands() for Postgres 9.4 or earlier

### DIFF
--- a/src/db/reco/addDDLActivityLoggingReco.sql
+++ b/src/db/reco/addDDLActivityLoggingReco.sql
@@ -40,12 +40,7 @@ SET LOCAL client_min_messages TO WARNING;
 -- the function is executed, it gets the timestamp, statement, and target object
 -- of the trigger DDL statement, and records those in the triggering student's
 -- record in the student table. It also increments the student's total DDL
--- statement count. If PostgreSQL version is before 9.5 objId will be set to N/A
--- for non-Drop DDL operations. This is done to account for the non-existence of
--- pg_event_trigger_ddl_commands() in those versions
-
---Remove assignment of objId and "AND ClassDB.isServerVersionAfter('9.4')" once
--- support for pg versions prior to 9.5 is dropped
+-- statement count
 
 --This function requires CREATE OR REPLACE for this function because it can't be
 -- dropped if the event triggers already exist.  For example, when re-runing this script
@@ -54,13 +49,12 @@ RETURNS event_trigger AS
 $$
 DECLARE
    --Name of the db object that was targeted by the triggering statement
-   objId VARCHAR(256) := 'N/A';
+   objId VARCHAR(256);
 BEGIN
    --We only want log DDL activity from ClassDB users
    IF ClassDB.isUser(SESSION_USER::ClassDB.IDNameDomain) THEN
-      --Check if the calling event is sql_drop or ddl_command_end and server
-      -- version is after 9.4
-      IF TG_EVENT = 'ddl_command_end' AND ClassDB.isServerVersionAfter('9.4') THEN
+      --Check if the calling event is sql_drop or ddl_command_end
+      IF TG_EVENT = 'ddl_command_end' THEN
          SELECT object_identity --Get the statement target object
          INTO objId
          FROM pg_event_trigger_ddl_commands() --can only be called on non-DROP ops

--- a/src/db/reco/addDDLActivityLoggingReco.sql
+++ b/src/db/reco/addDDLActivityLoggingReco.sql
@@ -55,8 +55,8 @@ BEGIN
    IF ClassDB.isUser(SESSION_USER::ClassDB.IDNameDomain) THEN
       --Check if the calling event is sql_drop or ddl_command_end
       IF TG_EVENT = 'ddl_command_end' THEN
-         --function pg_event_trigger_ddl_commands was introduced in pg9.5
-         -- remove the test for server version when support for pg9.4 ends
+         --Function pg_event_trigger_ddl_commands was introduced in pg9.5.
+         -- Remove the test for server version when support for pg9.4 ends
          IF ClassDB.isServerVersionBefore('9.5') THEN
             objId = 'N\A';
          ELSE
@@ -66,6 +66,10 @@ BEGIN
             WHERE object_identity IS NOT NULL
             ORDER BY object_identity;
          END IF;
+      --In pg9.4 'ddl_command_end' causes a log to be created with objId of N/A
+      -- to be inserted for a drop. Since there is already a log for drop this
+      -- TG_EVENT should be ignored in version 9.4 to avoid duplicate logs.
+      -- Remove test for server version when support for pg9.4 ends
       ELSIF TG_EVENT = 'sql_drop' AND ClassDB.isServerVersionAfter('9.4') THEN
          SELECT object_identity --Same thing, but for drop statements
          INTO objId

--- a/src/db/reco/addDDLActivityLoggingReco.sql
+++ b/src/db/reco/addDDLActivityLoggingReco.sql
@@ -58,7 +58,7 @@ BEGIN
          --Function pg_event_trigger_ddl_commands was introduced in pg9.5.
          -- Remove the test for server version when support for pg9.4 ends
          IF ClassDB.isServerVersionBefore('9.5') THEN
-            objId = 'N\A';
+            objId = 'N/A';
          ELSE
             SELECT object_identity --Get the statement target object
             INTO objId

--- a/tests/testDDLActivityLogging.sql
+++ b/tests/testDDLActivityLogging.sql
@@ -35,8 +35,8 @@ $$
 BEGIN
    --Check that no extra activity was logged. GROUP BY UserName and use HAVING COUNT(*)
    -- to check how many new activity rows have been added for each test user.
-   -- If COUNT(*) > 1, then too many connection rows were added for that user.
-   -- For PostgreSQL versions prior to 9.5 If COUNT(*) > 1, then too many
+   -- If COUNT(*) > 2, then too many connection rows were added for that user.
+   -- For PostgreSQL versions prior to 9.5 If COUNT(*) > 3, then too many
    -- connection rows were added for that user since N/A is filled in for blank rows
    --
    --Remove ClassDB.isServerVersionAfter('9.4') when support for pg versions before
@@ -46,7 +46,7 @@ BEGIN
                 FROM ClassDB.DDLActivity
                 WHERE userName IN ('ddltu01', 'ddlins01', 'ddldbm01')
                 GROUP BY UserName
-                HAVING COUNT(*) > 1)
+                HAVING COUNT(*) > 2)
      THEN
         RETURN 'FAIL: Code 1';
      END IF;

--- a/tests/testDDLActivityLogging.sql
+++ b/tests/testDDLActivityLogging.sql
@@ -36,31 +36,14 @@ BEGIN
    --Check that no extra activity was logged. GROUP BY UserName and use HAVING COUNT(*)
    -- to check how many new activity rows have been added for each test user.
    -- If COUNT(*) > 1, then too many connection rows were added for that user.
-   -- For PostgreSQL versions prior to 9.5 If COUNT(*) > 1, then too many
-   -- connection rows were added for that user since N/A is filled in for blank rows
-   --
-   --Remove ClassDB.isServerVersionAfter('9.4') when support for pg versions before
-   -- 9.5 is dropped
-   IF ClassDB.isServerVersionAfter('9.4') THEN
-     IF EXISTS (SELECT UserName
-                FROM ClassDB.DDLActivity
-                WHERE userName IN ('ddltu01', 'ddlins01', 'ddldbm01')
-                GROUP BY UserName
-                HAVING COUNT(*) > 1)
-     THEN
-        RETURN 'FAIL: Code 1';
-     END IF;
-   ELSE
-     IF EXISTS (SELECT UserName
-                FROM ClassDB.DDLActivity
-                WHERE userName IN ('ddltu01', 'ddlins01', 'ddldbm01')
-                GROUP BY UserName
-                HAVING COUNT(*) > 3)
-     THEN
-        RETURN 'FAIL: Code 1';
-     END IF;
+   IF EXISTS (SELECT UserName
+              FROM ClassDB.DDLActivity
+              WHERE userName IN ('ddltu01', 'ddlins01', 'ddldbm01')
+              GROUP BY UserName
+              HAVING COUNT(*) > 2)
+   THEN
+      RETURN 'FAIL: Code 1';
    END IF;
-
 
 
    --Check that all test users have activity logged. This test will fail one or
@@ -154,17 +137,7 @@ BEGIN
 
    RESET SESSION AUTHORIZATION;
 
-   --grant temporary access to functions to compare versions so that above tests
-   -- will work properly on pg versions prior to 9.5. Remove GRANTs once support
-   -- for pg versions prior to 9.5 is dropped.
-   GRANT EXECUTE ON FUNCTION ClassDB.isServerVersionAfter(VARCHAR, BOOLEAN)
-      TO ClassDB_Instructor, ClassDB_DBManager;
 
-   GRANT EXECUTE ON FUNCTION ClassDB.compareServerVersion(VARCHAR, BOOLEAN)
-      TO ClassDB_Instructor, ClassDB_DBManager;
-
-   GRANT EXECUTE ON FUNCTION ClassDB.compareServerVersion(VARCHAR, VARCHAR, BOOLEAN)
-      TO ClassDB_Instructor, ClassDB_DBManager;
 
    RAISE INFO '%, checkDDLActivityTable() (superuser)', pg_temp.checkDDLActivityTable();
 

--- a/tests/testDDLActivityLogging.sql
+++ b/tests/testDDLActivityLogging.sql
@@ -35,8 +35,8 @@ $$
 BEGIN
    --Check that no extra activity was logged. GROUP BY UserName and use HAVING COUNT(*)
    -- to check how many new activity rows have been added for each test user.
-   -- If COUNT(*) > 2, then too many connection rows were added for that user.
-   -- For PostgreSQL versions prior to 9.5 If COUNT(*) > 3, then too many
+   -- If COUNT(*) > 1, then too many connection rows were added for that user.
+   -- For PostgreSQL versions prior to 9.5 If COUNT(*) > 1, then too many
    -- connection rows were added for that user since N/A is filled in for blank rows
    --
    --Remove ClassDB.isServerVersionAfter('9.4') when support for pg versions before
@@ -46,7 +46,7 @@ BEGIN
                 FROM ClassDB.DDLActivity
                 WHERE userName IN ('ddltu01', 'ddlins01', 'ddldbm01')
                 GROUP BY UserName
-                HAVING COUNT(*) > 2)
+                HAVING COUNT(*) > 1)
      THEN
         RETURN 'FAIL: Code 1';
      END IF;


### PR DESCRIPTION
This PR adds a gaurd for pg_event_trigger_ddl_commands() in `addDDLActivityLoggingReco.sql` by checking server version. If the server version is pre-9.5 the `objId` will be set to N/A. 

N/A is probably not the best name for it and I am open to suggestions. It should contain at least one illegal identifier character so that it can not be confused for a valid object name.  

I had to also update `testDDLActivityLogging.sql` to support these changes. In order to allow users to check server version I had to `GRANT` temporary execution permission to related server version functions. 

fixes #234 