### PR TITLE
Guard uses of ALTER SYSTEM for pg9.3 compatability

### DIFF
--- a/src/server/reco/assertAlterSystemAvailability.sql
+++ b/src/server/reco/assertAlterSystemAvailability.sql
@@ -36,8 +36,7 @@ BEGIN
          MESSAGE = 'could not set logging-related settings',
          DETAIL = 'Logging-related settings must be set manually in Postgres'
                   ' 9.3 and earlier.',
-         HINT = 'See https://dassl.github.io/ClassDB/Setup for more'
-                ' information.';
+         HINT = 'Consult ClassDB documentation for more information.';
    END IF;
 END;
 $$;

--- a/src/server/reco/assertAlterSystemAvailability.sql
+++ b/src/server/reco/assertAlterSystemAvailability.sql
@@ -21,8 +21,6 @@
 -- postgresql.conf in pg9.3 or below. This script and any invocations of this
 -- script should be removed when support for pg9.3 is dropped.
 
-\set ON_ERROR_STOP on
-
 DO
 $$
 BEGIN

--- a/src/server/reco/assertAlterSystemAvailability.sql
+++ b/src/server/reco/assertAlterSystemAvailability.sql
@@ -1,0 +1,43 @@
+--assertAlterSystemAvailability.sql - ClassDB
+
+--Andrew Figueroa
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
+
+--(C) 2018- DASSL. ALL RIGHTS RESERVED.
+--Licensed to others under CC 4.0 BY-SA-NC
+--https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+--PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+--This script does not need to be run individually for an installation of
+-- ClassDB and does not modify the server or any database. It is called by
+-- other installation scripts when it is needed
+
+--This script asserts that the ALTER SYSTEM command is available for use by
+-- verifying that the current server version is not <9.4
+
+--Any configuration options that are set by ALTER SYSTEM must be set manually in
+-- postgresql.conf in pg9.3 or below. This script and any invocations of this
+-- script should be removed when support for pg9.3 is dropped.
+
+\set ON_ERROR_STOP on
+
+DO
+$$
+BEGIN
+   --Since this is a server script, ClassDB's server version comparers are not
+   --available. The following conditional reproduces the effect of calling
+   -- ClassDB.isServerVersionBefore('9.4')
+   IF 90400 > (SELECT setting::integer FROM pg_catalog.pg_settings
+               WHERE name = 'server_version_num')
+   THEN
+      RAISE EXCEPTION USING
+         MESSAGE = 'could not set logging-related settings',
+         DETAIL = 'Logging-related settings must be set manually in Postgres'
+                  ' 9.3 and earlier.',
+         HINT = 'See https://dassl.github.io/ClassDB/Setup for more'
+                ' information.';
+   END IF;
+END;
+$$;

--- a/src/server/reco/disableConnectionLoggingReco.psql
+++ b/src/server/reco/disableConnectionLoggingReco.psql
@@ -23,29 +23,8 @@
 -- logged. It does not revert log_destination and log_filname to the original settings
 -- prior to running enableConnectionLoggingReco.sql.
 
---ALTER SYSTEM statements were not available prior to Postgres 9.4 and so these
--- configuration options must be set manually in postgresql.conf in pg9.3 or
--- below. The following block, including setting on_error_stop, should be
--- removed when pg9.3 is no longer supported.
-\set ON_ERROR_STOP on
-DO
-$$
-BEGIN
-   --Since this is a server script, ClassDB's server version comparers are not
-   --available. The following conditional reproduces the effect of calling
-   -- ClassDB.isServerVersionBefore('9.4')
-   IF 90400 > (SELECT setting::integer FROM pg_catalog.pg_settings
-               WHERE name = 'server_version_num')
-   THEN
-      RAISE EXCEPTION USING
-         MESSAGE = 'could not set logging-related settings',
-         DETAIL = 'Logging-related settings must be set manually in Postgres'
-                  ' 9.3 and earlier.',
-         HINT = 'See https://dassl.github.io/ClassDB/Setup for more'
-                ' information.';
-   END IF;
-END;
-$$;
+--Assert that ALTER SYSTEM is available for use
+\ir assertAlterSystemAvailability.sql
 
 --The following changes are made:
 -- log_connections TO 'off' stops user connections from being recorded in the server log

--- a/src/server/reco/disableConnectionLoggingReco.psql
+++ b/src/server/reco/disableConnectionLoggingReco.psql
@@ -24,6 +24,7 @@
 -- prior to running enableConnectionLoggingReco.sql.
 
 --Assert that ALTER SYSTEM is available for use
+\set ON_ERROR_STOP on
 \ir assertAlterSystemAvailability.sql
 
 --The following changes are made:

--- a/src/server/reco/disableConnectionLoggingReco.psql
+++ b/src/server/reco/disableConnectionLoggingReco.psql
@@ -34,8 +34,8 @@ BEGIN
    --Since this is a server script, ClassDB's server version comparers are not
    --available. The following conditional reproduces the effect of calling
    -- ClassDB.isServerVersionBefore('9.4')
-   IF 90400 > (SELECT setting FROM pg_catalog.pg_settings
-               WHERE name = 'server_version_num')::INTEGER
+   IF 90400 > (SELECT setting::integer FROM pg_catalog.pg_settings
+               WHERE name = 'server_version_num')
    THEN
       RAISE EXCEPTION USING
          MESSAGE = 'could not set logging-related settings',

--- a/src/server/reco/disableConnectionLoggingReco.psql
+++ b/src/server/reco/disableConnectionLoggingReco.psql
@@ -23,6 +23,30 @@
 -- logged. It does not revert log_destination and log_filname to the original settings
 -- prior to running enableConnectionLoggingReco.sql.
 
+--ALTER SYSTEM statements were not available prior to Postgres 9.4 and so these
+-- configuration options must be set manually in postgresql.conf in pg9.3 or
+-- below. The following block, including setting on_error_stop, should be
+-- removed when pg9.3 is no longer supported.
+\set ON_ERROR_STOP on
+DO
+$$
+BEGIN
+   --Since this is a server script, ClassDB's server version comparers are not
+   --available. The following conditional reproduces the effect of calling
+   -- ClassDB.isServerVersionBefore('9.4')
+   IF 90400 > (SELECT setting FROM pg_catalog.pg_settings
+               WHERE name = 'server_version_num')::INTEGER
+   THEN
+      RAISE EXCEPTION USING
+         MESSAGE = 'could not set logging-related settings',
+         DETAIL = 'Logging-related settings must be set manually in Postgres'
+                  ' 9.3 and earlier.',
+         HINT = 'See https://dassl.github.io/ClassDB/Setup for more'
+                ' information.';
+   END IF;
+END;
+$$;
+
 --The following changes are made:
 -- log_connections TO 'off' stops user connections from being recorded in the server log
 ALTER SYSTEM SET log_connections TO 'off';

--- a/src/server/reco/enableConnectionLoggingReco.psql
+++ b/src/server/reco/enableConnectionLoggingReco.psql
@@ -19,9 +19,10 @@
 -- script because they pack each statement into a single command string.  This causes
 -- ALTER SYSTEM statements to fail.
 
---This script uses ALTER SYSTEM statements to change the Postgres server log
--- settings for the connection logging system. These statements must be run as
--- superuser and outside of any transaction.
+--This script uses ALTER SYSTEM statements to change the Postgres server log settings for
+-- the connection logging system. These statements must be run as superuser, but
+-- can't be run inside a TRANSACTION block, however they will still fail if they
+-- are run with insufficient permissions.
 
 --ALTER SYSTEM statements were not available prior to Postgres 9.4 and so these
 -- configuration options must be set manually in postgresql.conf in pg9.3 or

--- a/src/server/reco/enableConnectionLoggingReco.psql
+++ b/src/server/reco/enableConnectionLoggingReco.psql
@@ -24,30 +24,9 @@
 -- can't be run inside a TRANSACTION block, however they will still fail if they
 -- are run with insufficient permissions.
 
---ALTER SYSTEM statements were not available prior to Postgres 9.4 and so these
--- configuration options must be set manually in postgresql.conf in pg9.3 or
--- below. The following block, including setting on_error_stop, should be
--- removed when pg9.3 is no longer supported.
-\set ON_ERROR_STOP on
-DO
-$$
-BEGIN
-   --Since this is a server script, ClassDB's server version comparers are not
-   --available. The following conditional reproduces the effect of calling
-   -- ClassDB.isServerVersionBefore('9.4')
-   IF 90400 > (SELECT setting::integer FROM pg_catalog.pg_settings
-               WHERE name = 'server_version_num')
-   THEN
-      RAISE EXCEPTION USING
-         MESSAGE = 'could not set logging-related settings',
-         DETAIL = 'Logging-related settings must be set manually in Postgres'
-                  ' 9.3 and earlier.',
-         HINT = 'See https://dassl.github.io/ClassDB/Setup for more'
-                ' information.';
-   END IF;
-END;
-$$;
-   
+--Assert that ALTER SYSTEM is available for use
+\ir assertAlterSystemAvailability.sql
+
 --The following changes are made:
 --log_destination TO 'csvlog' cause the logs to be recorded in a csv format,
 -- making it possible to use the COPY statement on them

--- a/src/server/reco/enableConnectionLoggingReco.psql
+++ b/src/server/reco/enableConnectionLoggingReco.psql
@@ -19,12 +19,34 @@
 -- script because they pack each statement into a single command string.  This causes
 -- ALTER SYSTEM statements to fail.
 
---This script uses ALTER SYSTEM statements to change the Postgres server log settings for
--- the connection logging system. These statements must be run as superuser, but
--- can't be run inside a TRANSACTION block, however they will still fail if they
--- are run with insufficient permissions.
+--This script uses ALTER SYSTEM statements to change the Postgres server log
+-- settings for the connection logging system. These statements must be run as
+-- superuser and outside of any transaction.
 
-
+--ALTER SYSTEM statements were not available prior to Postgres 9.4 and so these
+-- configuration options must be set manually in postgresql.conf in pg9.3 or
+-- below. The following block, including setting on_error_stop, should be
+-- removed when pg9.3 is no longer supported.
+\set ON_ERROR_STOP on
+DO
+$$
+BEGIN
+   --Since this is a server script, ClassDB's server version comparers are not
+   --available. The following conditional reproduces the effect of calling
+   -- ClassDB.isServerVersionBefore('9.4')
+   IF 90400 > (SELECT setting FROM pg_catalog.pg_settings
+               WHERE name = 'server_version_num')::INTEGER
+   THEN
+      RAISE EXCEPTION USING
+         MESSAGE = 'could not set logging-related settings',
+         DETAIL = 'Logging-related settings must be set manually in Postgres'
+                  ' 9.3 and earlier.',
+         HINT = 'See https://dassl.github.io/ClassDB/Setup for more'
+                ' information.';
+   END IF;
+END;
+$$;
+   
 --The following changes are made:
 --log_destination TO 'csvlog' cause the logs to be recorded in a csv format,
 -- making it possible to use the COPY statement on them

--- a/src/server/reco/enableConnectionLoggingReco.psql
+++ b/src/server/reco/enableConnectionLoggingReco.psql
@@ -25,6 +25,7 @@
 -- are run with insufficient permissions.
 
 --Assert that ALTER SYSTEM is available for use
+\set ON_ERROR_STOP on
 \ir assertAlterSystemAvailability.sql
 
 --The following changes are made:

--- a/src/server/reco/enableConnectionLoggingReco.psql
+++ b/src/server/reco/enableConnectionLoggingReco.psql
@@ -35,8 +35,8 @@ BEGIN
    --Since this is a server script, ClassDB's server version comparers are not
    --available. The following conditional reproduces the effect of calling
    -- ClassDB.isServerVersionBefore('9.4')
-   IF 90400 > (SELECT setting FROM pg_catalog.pg_settings
-               WHERE name = 'server_version_num')::INTEGER
+   IF 90400 > (SELECT setting::integer FROM pg_catalog.pg_settings
+               WHERE name = 'server_version_num')
    THEN
       RAISE EXCEPTION USING
          MESSAGE = 'could not set logging-related settings',


### PR DESCRIPTION
This PR adds a guard that prevents any statements located in `enableconnectionLoggingReco.psql` and `disableConnectionLoggingReco.psql` from being run if the Postgres server version is < 9.4. This guard is needed because the `ALTER SYSTEM` statements were not available prior to pg9.4, and these settings need to instead be manually set in the `postgresql.conf` file. Also note that because of how the guard is implemented, it is no longer possible to use the `addAllToServer.psql` script to add everything to the server [when using Postgres 9.3]* (which is okay since there is only one other server file apart from these two).

\*Edited to mention that the issue with `addAllToServer.psql` only applies to 9.3

As mentioned in the script comments, ClassDB's server comparers are not accessible. An equivalent call to one of these functions is included in a comment to make locating the backwards-comparable alternative easier.

Currently, I believe it makes more sense to include details about manually setting these server parameters in [ClassDB's Setup page](https://github.com/DASSL/ClassDB/wiki/Setup). However, please feel free to suggest an alternative location.

Closes: #228 