### PR TITLE
Guard use of pg_signal_backend

### DIFF
--- a/src/server/core/initalizeServerCore.sql
+++ b/src/server/core/initalizeServerCore.sql
@@ -66,7 +66,18 @@ BEGIN
    PERFORM pg_temp.createGroupRole('classdb');
 
    ALTER ROLE ClassDB CREATEROLE CREATEDB;
-   GRANT pg_signal_backend TO ClassDB;
+
+   --server role pg_signal_backend was introduced in pg9.6
+   -- remove this check when pg9.5 is no longer supported
+   --The setting server_version_num returns an integer form of version number
+   -- e.g., 90603 for version 9.6.3; 90500 for 9.5.0
+   -- https://www.postgresql.org/docs/10/static/runtime-config-preset.html
+   --Query setting directly because helpers fns are unavailable in this script
+   IF 90600 <= (SELECT setting::integer FROM pg_catalog.pg_settings
+              WHERE name = 'server_version_num'
+             ) THEN
+      GRANT pg_signal_backend TO ClassDB;
+   END IF;
 
    PERFORM pg_temp.createGroupRole('classdb_student');
    PERFORM pg_temp.createGroupRole('classdb_instructor');

--- a/src/server/core/initalizeServerCore.sql
+++ b/src/server/core/initalizeServerCore.sql
@@ -74,7 +74,7 @@ BEGIN
    -- https://www.postgresql.org/docs/10/static/runtime-config-preset.html
    --Query setting directly because helpers fns are unavailable in this script
    IF 90600 <= (SELECT setting::integer FROM pg_catalog.pg_settings
-              WHERE name = 'server_version_num'
+                WHERE name = 'server_version_num'
              ) THEN
       GRANT pg_signal_backend TO ClassDB;
    END IF;

--- a/src/server/core/initalizeServerCore.sql
+++ b/src/server/core/initalizeServerCore.sql
@@ -75,7 +75,7 @@ BEGIN
    --Query setting directly because helpers fns are unavailable in this script
    IF 90600 <= (SELECT setting::integer FROM pg_catalog.pg_settings
                 WHERE name = 'server_version_num'
-             ) THEN
+               ) THEN
       GRANT pg_signal_backend TO ClassDB;
    END IF;
 


### PR DESCRIPTION
The changes in this PR guard the use of the predefined server role `pg_signal_backend` only in versions 9.6 or later. Fixes #225 

**Note:** Using the server version to address this issue is technically incorrect because the functionality in question is determined by the existence of a specific server role which can be tested in the `pg_roles` table. However, testing for server version is more practical and maintainable, and we should be able to trust no one has removed a server role. (We make many such assumptions about the environment.)