### PR TITLE
Use machine-readable version number to determine current server's version

### DIFF
--- a/tests/testServerVersionComparers.sql
+++ b/tests/testServerVersionComparers.sql
@@ -34,119 +34,115 @@ CREATE OR REPLACE FUNCTION pg_temp.testServerVersionComparers() RETURNS TEXT AS
 $$
 BEGIN
 
-   --test function to return server's version number
-   --can't test equality because value from current_setting can have distro suffix
-   -- instead, test if value from current_setting starts with server version
-   IF POSITION(ClassDB.getServerVersion()
-      IN current_setting('server_version')) <> 1
+   --test function to convert int server version to string
+   IF ClassDB.intServerVersionToString(100001) <> '10.1'
+      OR ClassDB.intServerVersionToString(110000) <> '11.0'
+      OR ClassDB.intServerVersionToString(90105) <> '9.1.5'
+      OR ClassDB.intServerVersionToString(90200) <> '9.2.0'
+      OR ClassDB.intServerVersionToString(91201) <> '9.12.1'
+      OR ClassDB.intServerVersionToString(91427) <> '9.14.27'
+      OR ClassDB.intServerVersionToString(110046) <> '11.46'
    THEN
       RETURN 'FAIL: Code 1';
+   END IF;
+
+   --test function to return current server's version number
+   --can't test equality because value from current_setting can have distro suffix
+   -- instead, test if value from current_setting starts with server version
+   IF POSITION(ClassDB.getServerVersion() IN current_setting('server_version')) <> 1
+   THEN
+      RETURN 'FAIL: Code 2';
    END IF;
 
 
    --test any two version numbers: test part 2
    IF ClassDB.compareServerVersion('9.6', '9.5') <= 0 THEN
-      RETURN 'FAIL: Code 2';
-   END IF;
-
-   IF ClassDB.compareServerVersion('9.5', '9.6') >= 0 THEN
       RETURN 'FAIL: Code 3';
    END IF;
 
-   IF ClassDB.compareServerVersion('8.5', '9.6') >= 0 THEN
+   IF ClassDB.compareServerVersion('9.5', '9.6') >= 0 THEN
       RETURN 'FAIL: Code 4';
    END IF;
 
-   IF ClassDB.compareServerVersion('9.6', '8.5') <= 0 THEN
+   IF ClassDB.compareServerVersion('8.5', '9.6') >= 0 THEN
       RETURN 'FAIL: Code 5';
    END IF;
 
-
-   --test any two version numbers: test distro suffix
-   IF ClassDB.compareServerVersion('10.3', '10.3 (Ubuntu 10.3-1)') <> 0 THEN
+   IF ClassDB.compareServerVersion('9.6', '8.5') <= 0 THEN
       RETURN 'FAIL: Code 6';
-   END IF;
-
-   IF ClassDB.compareServerVersion('10.3 (Ubuntu 10.3-1)', '10.3') <> 0 THEN
-      RETURN 'FAIL: Code 7';
-   END IF;
-
-   --intentionally no space before opening parenthesis
-   IF ClassDB.compareServerVersion('10.1(distro 1)', '10.2(distro 2)') >= 0 THEN
-      RETURN 'FAIL: Code 8';
    END IF;
 
 
    --test any two version numbers: ignore part 2
    IF ClassDB.compareServerVersion('9.6', '9.6', FALSE) <> 0 THEN
-      RETURN 'FAIL: Code 9';
+      RETURN 'FAIL: Code 7';
    END IF;
 
    IF ClassDB.compareServerVersion('9.6', '9.5', FALSE) <> 0 THEN
-      RETURN 'FAIL: Code 10';
+      RETURN 'FAIL: Code 8';
    END IF;
 
    IF ClassDB.compareServerVersion('9.5', '9.6', FALSE) <> 0 THEN
-      RETURN 'FAIL: Code 11';
+      RETURN 'FAIL: Code 9';
    END IF;
 
 
    --test any two version numbers: single-part input
    IF ClassDB.compareServerVersion('10', '10', FALSE) <> 0 THEN
-      RETURN 'FAIL: Code 12';
+      RETURN 'FAIL: Code 10';
    END IF;
 
    IF ClassDB.compareServerVersion('10', '9.5', FALSE) <= 0 THEN
-      RETURN 'FAIL: Code 13';
+      RETURN 'FAIL: Code 11';
    END IF;
 
    IF ClassDB.compareServerVersion('9.5', '10', FALSE) >= 0 THEN
-      RETURN 'FAIL: Code 14';
+      RETURN 'FAIL: Code 12';
    END IF;
 
 
    --test some version number with server's version number
    IF ClassDB.compareServerVersion('9.5')
       <>
-      ClassDB.compareServerVersion('9.5', current_setting('server_version'))
+      ClassDB.compareServerVersion('9.5', ClassDB.getServerVersion())
    THEN
-      RETURN 'FAIL: Code 15';
+      RETURN 'FAIL: Code 13';
    END IF;
 
 
    --shortcut functions
    IF ClassDB.isServerVersionBefore('0') THEN
-      RETURN 'FAIL: Code 16';
+      RETURN 'FAIL: Code 14';
    END IF;
 
    IF ClassDB.isServerVersionBefore('0', FALSE) THEN
-      RETURN 'FAIL: Code 17';
+      RETURN 'FAIL: Code 15';
    END IF;
 
    IF NOT ClassDB.isServerVersionAfter('0') THEN
-      RETURN 'FAIL: Code 18';
+      RETURN 'FAIL: Code 16';
    END IF;
 
    IF NOT ClassDB.isServerVersionAfter('0', FALSE) THEN
-      RETURN 'FAIL: Code 19';
+      RETURN 'FAIL: Code 17';
    END IF;
 
-   IF NOT ClassDB.isServerVersion(current_setting('server_version')) THEN
-      RETURN 'FAIL: Code 20';
+   IF NOT ClassDB.isServerVersion(ClassDB.getServerVersion()) THEN
+      RETURN 'FAIL: Code 18';
    END IF;
 
    IF ClassDB.isServerVersion('0.8') THEN
-      RETURN 'FAIL: Code 21';
+      RETURN 'FAIL: Code 19';
    END IF;
 
    --the following tests fail when Postgres version reaches 100000.8
    -- just change the argument at that point, or rewrite the tests
    IF NOT ClassDB.isServerVersionBefore('100000.8') THEN
-      RETURN 'FAIL: Code 22';
+      RETURN 'FAIL: Code 20';
    END IF;
 
    IF ClassDB.isServerVersionAfter('100000.8') THEN
-      RETURN 'FAIL: Code 23';
+      RETURN 'FAIL: Code 21';
    END IF;
 
    RETURN 'PASS';


### PR DESCRIPTION
This PR makes the following changes:
- Add a new function `ClassDB.intServerVersionToString` to convert a machine-readable pg server version number to string
- Use the server setting `server_version_num` instead of 'server_version' in function `ClassDB.getServerVersion`
- Remove support for distro suffix in function `ClassDB.compareServerVersion`
- Mark all functions in the script `addServerVersionComparersCore.sql` as `IMMUTABLE`
- Add test for new functionality
- Remove test for version numbers with distro-suffix

Fixes #263 #267