### PR TITLE
Guard GRANT to CURRENT_USER in pg9.4 or earlier

### DIFF
--- a/src/db/core/initializeDBCore.sql
+++ b/src/db/core/initializeDBCore.sql
@@ -86,13 +86,25 @@ BEGIN
    --Allow ClassDB and ClassDB users to create schemas on the current database
    EXECUTE format('GRANT CREATE ON DATABASE %I TO ClassDB, ClassDB_Instructor,'
                   ' ClassDB_DBManager, ClassDB_Student', currentDB);
+
+   --Grant ClassDB to the current user
+   -- allows altering privileges of objects, even after being owned by ClassDB
+   --The use of CURRENT_USER in a GRANT query is permitted from pg9.5
+   -- remove this check when pg9.4 is no longer supported
+   --Directly query the server because helper fns are unavailable in this script
+   IF 90400 >= (SELECT setting::integer FROM pg_catalog.pg_settings
+                WHERE name = 'server_version_num'
+               ) THEN
+      EXECUTE FORMAT('GRANT ClassDB TO %s', CURRENT_USER);
+   ELSE
+      --remove the guard and keep the following code line when pg9.4 is unsupported
+      GRANT ClassDB TO CURRENT_USER;
+   END IF;
+
 END
 $$;
 
 
---Grant ClassDB to the current user
--- allows altering privileges of objects, even after being owned by ClassDB
-GRANT ClassDB TO CURRENT_USER;
 
 --Prevent users who are not instructors from modifying the public schema
 -- public schema contains objects and functions students can read

--- a/src/db/core/initializeDBCore.sql
+++ b/src/db/core/initializeDBCore.sql
@@ -89,17 +89,12 @@ BEGIN
 
    --Grant ClassDB to the current user
    -- allows altering privileges of objects, even after being owned by ClassDB
-   --The use of CURRENT_USER in a GRANT query is permitted from pg9.5
-   -- remove this check when pg9.4 is no longer supported
-   --Directly query the server because helper fns are unavailable in this script
-   IF 90400 >= (SELECT setting::integer FROM pg_catalog.pg_settings
-                WHERE name = 'server_version_num'
-               ) THEN
-      EXECUTE FORMAT('GRANT ClassDB TO %s', CURRENT_USER);
-   ELSE
-      --remove the guard and keep the following code line when pg9.4 is unsupported
-      GRANT ClassDB TO CURRENT_USER;
-   END IF;
+
+   --The use of CURRENT_USER in a GRANT query is permitted only from pg9.5
+   -- Use dynamic SQL on all pg versions so the script compiles on pg9.4 and earlier
+   -- replace dynamic SQL with the commmented out query when pg9.4 is unsupported
+   --GRANT ClassDB TO CURRENT_USER;
+   EXECUTE FORMAT('GRANT ClassDB TO %s', CURRENT_USER);
 
 END
 $$;

--- a/tests/testRoleBaseMgmt.sql
+++ b/tests/testRoleBaseMgmt.sql
@@ -134,7 +134,7 @@ BEGIN
 
    --create a server role with NOLOGIN directly, create a schema for the new role
    CREATE ROLE s1 NOLOGIN;
-   GRANT s1 to CURRENT_USER;
+   PERFORM ClassDB.grantRole('s1');
    CREATE SCHEMA s1 AUTHORIZATION s1;
 
    --s1 has no LOGIN (should get LOGIN after createRole)


### PR DESCRIPTION
This PR changes two uses of `GRANT` query involving `CURRENT_USER`:
- `initializeDBCore.sql`: Use a guard to execute dynamic SQL for granting
- `testRoleBaseMgmt.sql`: Reuse helper function `ClassDB.grantRole` to keep the script simple and maintainable

Fixes #229