### PR TITLE
Add Guard for DROP OWNED BY

### DIFF
--- a/tests/testDisallowSchemaDrop.sql
+++ b/tests/testDisallowSchemaDrop.sql
@@ -33,7 +33,7 @@ $$;
 -- 9.4 and lower versions need dynamic queries to work with CURRENT_USER in
 -- DROP OWNED BY queries. Remove this function once support for pg9.4 is dropped
 -- and use the following 'DROP OWNED BY CURRENT_USER' and its variations.
-CREATE OR REPLACE FUNCTION pg_temp.doDropOwnedByCurrentUser(query VARCHAR) RETURNS VOID AS
+CREATE OR REPLACE FUNCTION pg_temp.doDropOwnedByCurrentUser(queryHead VARCHAR) RETURNS VOID AS
 $$
 BEGIN
   EXECUTE FORMAT('%s %s', $1, CURRENT_USER);

--- a/tests/testDisallowSchemaDrop.sql
+++ b/tests/testDisallowSchemaDrop.sql
@@ -29,7 +29,7 @@ END
 $$;
 
 --Executes supplied drop query using CURRENT_USER dynamically which is needed
--- pg versions lower then 9.5  which added CURRENT_USER to DROP OWNED quieries.
+-- pg versions lower then 9.5  which added CURRENT_USER to DROP OWNED queries.
 -- 9.4 and lower versions need dynamic queries to work with CURRENT_USER in
 -- DROP OWNED BY queries. Remove this function once support for pg9.4 is dropped
 -- and use the following 'DROP OWNED BY CURRENT_USER' and its variations.
@@ -40,7 +40,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
---------------------------------------------------------------------------------
+
 
 DO
 $$

--- a/tests/testDisallowSchemaDrop.sql
+++ b/tests/testDisallowSchemaDrop.sql
@@ -28,6 +28,19 @@ BEGIN
 END
 $$;
 
+--Executes supplied drop query function with the CURRENT_USER which is needed
+-- because pg version 9.5 added CURRENT_USER to DROP OWNED quieries. All lower,
+-- versions need dynamic queries to work with CURRENT_USER in DROP OWNED BY queries.
+-- Remove this function once support for pg9.4 is dropped and use the following:
+-- 'DROP OWNED BY CURRENT_USER' and its variations.
+CREATE OR REPLACE FUNCTION pg_temp.doDropOwnedByCurrentUser(query VARCHAR) RETURNS VOID AS
+$$
+BEGIN
+  EXECUTE FORMAT('%s %s', $1, CURRENT_USER);
+END;
+$$ LANGUAGE plpgsql;
+
+--------------------------------------------------------------------------------
 
 DO
 $$
@@ -104,7 +117,7 @@ BEGIN
    --drop owned objects: should cause exception
    --spelling 'DrOP oWNeD' intentional to test if the event handler ignores case
    BEGIN
-      DrOP oWNeD BY CURRENT_USER;
+      PERFORM pg_temp.doDropOwnedByCurrentUser('DrOP oWNeD BY ');
       RAISE INFO '%   drop owned by student disallowed', 'FAIL: Code 6';
 
    EXCEPTION
@@ -137,7 +150,7 @@ BEGIN
 
    --drop owned objects: should not cause exception
    BEGIN
-      DROP OWNED BY CURRENT_USER;
+      PERFORM pg_temp.doDropOwnedByCurrentUser('DROP OWNED BY ');
       RAISE INFO '%   drop owned by instructor', 'PASS';
 
    EXCEPTION
@@ -167,7 +180,7 @@ BEGIN
 
    --drop owned objects: should not cause exception
    BEGIN
-      DROP OWNED BY CURRENT_USER;
+      PERFORM pg_temp.doDropOwnedByCurrentUser('DROP OWNED BY ');
       RAISE INFO '%   drop owned by DB manager', 'PASS';
 
    EXCEPTION
@@ -198,7 +211,7 @@ BEGIN
 
    --drop owned objects: should not cause exception
    BEGIN
-      DROP OWNED BY CURRENT_USER;
+      PERFORM pg_temp.doDropOwnedByCurrentUser('DROP OWNED BY ');
       RAISE INFO '%   drop owned by non-ClassDB user', 'PASS';
 
    EXCEPTION
@@ -238,7 +251,7 @@ BEGIN
 
    --drop owned objects: should not cause exception
    BEGIN
-      DROP OWNED BY CURRENT_USER;
+      PERFORM pg_temp.doDropOwnedByCurrentUser('DROP OWNED BY ');
       RAISE INFO '%   drop owned by student allowed', 'PASS';
 
    EXCEPTION

--- a/tests/testDisallowSchemaDrop.sql
+++ b/tests/testDisallowSchemaDrop.sql
@@ -28,11 +28,11 @@ BEGIN
 END
 $$;
 
---Executes supplied drop query function with the CURRENT_USER which is needed
--- because pg version 9.5 added CURRENT_USER to DROP OWNED quieries. All lower,
--- versions need dynamic queries to work with CURRENT_USER in DROP OWNED BY queries.
--- Remove this function once support for pg9.4 is dropped and use the following:
--- 'DROP OWNED BY CURRENT_USER' and its variations.
+--Executes supplied drop query using CURRENT_USER dynamically which is needed
+-- pg versions lower then 9.5  which added CURRENT_USER to DROP OWNED quieries.
+-- 9.4 and lower versions need dynamic queries to work with CURRENT_USER in
+-- DROP OWNED BY queries. Remove this function once support for pg9.4 is dropped
+-- and use the following 'DROP OWNED BY CURRENT_USER' and its variations.
 CREATE OR REPLACE FUNCTION pg_temp.doDropOwnedByCurrentUser(query VARCHAR) RETURNS VOID AS
 $$
 BEGIN


### PR DESCRIPTION
This PR adds a temporary function that when given a `DROP OWNED BY` query it will dynamically execute the query with an attached `CURRENT_USER`. All uses of `DROP OWNED BY CURRENT_USER` have been replaced with this temporary function with the replaced query as the parameter. This also maintains the purposefully odd case of `DrOP oWNeD BY ` on Ln120.

Fixes #269 