### PR TITLE
Fix server initialization filename

### DIFF
--- a/src/server/core/addAllServerCore.psql
+++ b/src/server/core/addAllServerCore.psql
@@ -25,4 +25,4 @@
 -- used rather then the program's current directory
 
 \set ON_ERROR_STOP on
-\ir initalizeServerCore.sql
+\ir initializeServerCore.sql

--- a/src/server/core/initializeServerCore.sql
+++ b/src/server/core/initializeServerCore.sql
@@ -1,4 +1,4 @@
---initalizeServerCore.sql - ClassDB
+--initializeServerCore.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
 --Data Science & Systems Lab (DASSL)


### PR DESCRIPTION
This PR corrects the filename for the server initialization script from `initalizeServerCore.sql` to `initializeServerCore.sql`. Corresponding changes were made elsewhere, including the Scripts page of the documentation.

Fixes #272 