### PR TITLE
Fix removeAllFromDB.sql

### DIFF
--- a/src/db/removeAllFromDB.sql
+++ b/src/db/removeAllFromDB.sql
@@ -103,6 +103,8 @@ DROP FUNCTION IF EXISTS ClassDB.allowSchemaDrop();
 
 DROP FUNCTION IF EXISTS ClassDB.getSessionID();
 
+DROP FUNCTION IF EXISTS ClassDB.killConnection(INTEGER);
+
 
 --Try to drop all ClassDB owned functions in ClassDB schema
 DROP OWNED BY ClassDB;

--- a/src/db/removeAllFromDB.sql
+++ b/src/db/removeAllFromDB.sql
@@ -103,7 +103,7 @@ DROP FUNCTION IF EXISTS ClassDB.allowSchemaDrop();
 
 DROP FUNCTION IF EXISTS ClassDB.getSessionID();
 
-DROP FUNCTION IF EXISTS ClassDB.killConnection(INTEGER);
+DROP FUNCTION IF EXISTS ClassDB.killConnection(INT);
 
 
 --Try to drop all ClassDB owned functions in ClassDB schema


### PR DESCRIPTION
Added a drop function to `removeAllFromDB.sql` which incorporates a drop for `ClassDB.killConnection(INTEGER)` which was previously breaking the script. 

Fixes #225  