### PR TITLE
Clarify comment on granting login privilege

### DIFF
--- a/src/db/core/addRoleBaseMgmtCore.sql
+++ b/src/db/core/addRoleBaseMgmtCore.sql
@@ -311,7 +311,7 @@ BEGIN
 
    --in case a pre-existing server role is now registered, give that role LOGIN
    -- capability if it is a user (in case that privilege was somehow removed);
-   -- but don'o't remove LOGIN from a team: instr. may have reason to let a team login
+   -- but don't remove LOGIN from a team: instr. may have reason to let a team login
    IF NOT($3 OR ClassDB.canLogin($1)) THEN
       EXECUTE FORMAT('ALTER ROLE %s LOGIN', $1);
    END IF;
@@ -352,7 +352,7 @@ BEGIN
    -- if role is already known, set full name and extra info to new values
    -- cannot use ON CONFLICT because table has no PK or constraint
    --  seems the unique index can't be used despite the example in Postgres docs
-   --  for ON CONFLICT ON CONSTRAINT: see the last-but-one example at
+   --  for ON CONFLICT ON CONSTRAINT: see the second-from-last example at
    --  https://www.postgresql.org/docs/9.6/static/sql-insert.html
    IF ClassDB.isRoleKnown($1) THEN
       UPDATE ClassDB.RoleBase R

--- a/src/db/core/addRoleBaseMgmtCore.sql
+++ b/src/db/core/addRoleBaseMgmtCore.sql
@@ -309,9 +309,9 @@ BEGIN
                     );
    END IF;
 
-   --give the server role LOGIN capability if it is a user
-   --do not remove LOGIN for a team, because instructors may have their reasons
-   -- to make a LOGIN server role a team
+   --in case a pre-existing server role is now registered, give that role LOGIN
+   -- capability if it is a user (in case that privilege was somehow removed);
+   -- but don'o't remove LOGIN from a team: instr. may have reason to let a team login
    IF NOT($3 OR ClassDB.canLogin($1)) THEN
       EXECUTE FORMAT('ALTER ROLE %s LOGIN', $1);
    END IF;


### PR DESCRIPTION
This commit revises the comment associated with the code to grant login privilege when a role is created. Fixes #280

Only comment change; **no code change**.