### PR TITLE
Limit database connection only to users known to that database

### DIFF
--- a/src/db/core/addRoleBaseMgmtCore.sql
+++ b/src/db/core/addRoleBaseMgmtCore.sql
@@ -309,9 +309,9 @@ BEGIN
                     );
    END IF;
 
-   --give the server role LOGIN capability if it is a user
-   --do not remove LOGIN for a team, because instructors may have their reasons
-   -- to make a LOGIN server role a team
+   --in case a pre-existing server role is now registered, give that role LOGIN
+   -- capability if it is a user (in case that privilege was somehow removed);
+   -- but don'o't remove LOGIN from a team: instr. may have reason to let a team login
    IF NOT($3 OR ClassDB.canLogin($1)) THEN
       EXECUTE FORMAT('ALTER ROLE %s LOGIN', $1);
    END IF;

--- a/src/db/core/initializeDBCore.sql
+++ b/src/db/core/initializeDBCore.sql
@@ -78,10 +78,19 @@ BEGIN
    -- Postgres grants CONNECT to all by default
    EXECUTE format('REVOKE CONNECT ON DATABASE %I FROM PUBLIC', currentDB);
 
+
+   --the comment and code segment within lined comments can be reinstated if
+   -- db-specific roles are used to address Issue #277
+   -- at that time also look at related comments and code in functions createRole
+   -- and revokeClassDBRole
+   -- the purpose of the disabled code is to address Issue #278 before Issue #277
+
+--------------------------------------------------------------------------------
    --Let only app-specific roles connect to the DB
    -- no need for ClassDB to connect to the DB
-   EXECUTE format('GRANT CONNECT ON DATABASE %I TO ClassDB_Instructor, '
-                  'ClassDB_Student, ClassDB_DBManager', currentDB);
+   --EXECUTE format('GRANT CONNECT ON DATABASE %I TO ClassDB_Instructor, '
+   --               'ClassDB_Student, ClassDB_DBManager', currentDB);
+--------------------------------------------------------------------------------
 
    --Allow ClassDB and ClassDB users to create schemas on the current database
    EXECUTE format('GRANT CREATE ON DATABASE %I TO ClassDB, ClassDB_Instructor,'


### PR DESCRIPTION
The commits in this PR remove automatic DB connection to ClassDB group roles (at DB initialization) and instead manage that permission separately for each login role: grants permission in function `createRole`; revokes permission in function `revokeClassDBRole` if the role has no more ClassDB roles.

These commits fix #278.

This fix can be removed when Issue #277 is fixed, assuming that issue is addressed by creating database-specific names for ClassDB group roles as [proposed in a comment](https://github.com/DASSL/ClassDB/issues/277#issuecomment-417973035) at that issue.

The changes are tested manually. Privilege tests need to be updated.